### PR TITLE
feat(totp): per-bucket TOTP second factor for password sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ directories; full retrospectives live in `TASKS.md`'s git history and the knowle
 
 ### Added
 
+- TOTP second factor per user bucket: `totpRequired` makes a password sign-in also require a
+  six-digit authenticator code, with enrolment at registration and at the first sign-in of an
+  existing account, RFC 4226/6238 implemented in-repo against the published test vectors, replay and
+  two-tier throttling, `amr: ['pwd','otp']` on the ID token, and operator recovery via
+  `DELETE /admin/api/buckets/:id/users/:uid/totp` (audited, ends sessions, exposed to MCP as
+  `bucket_user_totp_clear`). Federated sign-in is not gated (spec 027)
 - CORS support: preflight handling, open CORS on discovery/JWKS, client-based CORS on the token
   family driven by a per-project `corsOrigins` allow-list, `cors.enabled` setting (spec 011)
 - Hardening headers on every response that is not a rendered page — `nosniff`, `no-referrer`, and a

--- a/TASKS.md
+++ b/TASKS.md
@@ -95,6 +95,29 @@ red by design (2622 errors — task 26 owns the strategy).
   **Consider splitting** — the two channels and the token parameter are independent enough for
   separate Spec Kit cycles if the first one runs long.
 
+### 39. Brute-force protection on the password sign-in door — Implement
+
+- (P1; found 2026-08-27 during the production-readiness review — nothing in the repo throttles the
+  login door.)
+- **Context:** `POST /ui/:uid/login` (`lib/interactions/index.ts:294`) runs `findByEmail` →
+  `Bun.password.verify` with no failed-attempt tracking, no cooldown, no lockout — unlimited
+  credential-stuffing against any known address, and each guess costs the server a full argon2
+  verify on a `shared-cpu-1x` machine, so the same door doubles as a cheap CPU-exhaustion vector.
+  Every sibling secret surface is already protected (verification codes cap at 5 attempts,
+  `lib/verification/consts.ts:12`; resends and password-reset requests are cooldown + daily-capped
+  via `lib/helpers/rate_window.ts`), which makes the untouched login door an anomaly, not a policy.
+- **Expected result:** Failed password attempts are tracked per `${bucketId}:${email}` (the
+  established computed-id shape — a new unowned throttle area in the storage inventory, added to
+  the email-scoped cascade list in `lib/helpers/cascade.ts:41`) with a cooldown after N consecutive
+  failures; a successful sign-in clears the counter; a throttled attempt renders the login page
+  with the existing neutral message posture (never revealing whether the account exists or whether
+  the password was right). Planning decides: N and the cooldown curve; whether an IP dimension is
+  worth adding behind Fly's proxy (`Fly-Client-IP`) or per-identity throttling suffices; and
+  whether `/token` client-secret authentication deserves the same treatment (note the constant-time
+  compare already there). Tests: N failures → cooldown refusal even with the correct password until
+  expiry; success resets the counter; other accounts and buckets unaffected; drift guards pass with
+  the new area declared.
+
 ---
 
 ## P2 — Incomplete product surfaces
@@ -394,6 +417,8 @@ red by design (2622 errors — task 26 owns the strategy).
 
 ## Suggested order
 
+- **39** (login brute-force protection) — the last open item an attacker, rather than an operator,
+  can reach; the throttle primitives it needs already exist.
 - **12** (guard the throwing toggles) → **13** (protocol conformance batch).
 - Debt with production evidence: **37** (storage encoding contract) — no database, no barriers, and
   it closes the class that actually broke production; **38** (fidelity suite) is the large one and

--- a/lib/adapters/memory/userBucketStore.ts
+++ b/lib/adapters/memory/userBucketStore.ts
@@ -15,6 +15,7 @@ export class UserBucketStore implements UserBucketStoreInstance {
 		registrationOpen?: boolean;
 		emailVerificationRequired?: boolean;
 		verificationMethod?: UserBucket['verificationMethod'];
+		totpRequired?: boolean;
 	}): Promise<UserBucket> {
 		const now = new Date();
 		const bucket: UserBucket = {
@@ -30,6 +31,9 @@ export class UserBucketStore implements UserBucketStoreInstance {
 			registrationOpen: data.registrationOpen ?? true,
 			emailVerificationRequired: data.emailVerificationRequired ?? false,
 			verificationMethod: data.verificationMethod ?? 'link',
+			// Off unless asked for: turning it on is a decision an operator makes, never one a
+			// default makes for them.
+			totpRequired: data.totpRequired ?? false,
 			createdAt: now,
 			updatedAt: now
 		};
@@ -45,6 +49,9 @@ export class UserBucketStore implements UserBucketStoreInstance {
 	private withDefaults(bucket: UserBucket): UserBucket {
 		bucket.passwordLogin ??= true;
 		bucket.federation ??= [];
+		// Same reasoning in the other direction: undefined is falsy, and reading it as "not required"
+		// is exactly right for a bucket written before the second factor existed.
+		bucket.totpRequired ??= false;
 		return bucket;
 	}
 
@@ -76,6 +83,7 @@ export class UserBucketStore implements UserBucketStoreInstance {
 				| 'registrationOpen'
 				| 'emailVerificationRequired'
 				| 'verificationMethod'
+				| 'totpRequired'
 			>
 		>
 	): Promise<UserBucket | null> {

--- a/lib/adapters/memory/userStore.ts
+++ b/lib/adapters/memory/userStore.ts
@@ -33,7 +33,11 @@ export class UserStore implements UserStoreInstance {
 			claims: user.claims,
 			// Seeding a link is how a federation spec sets up "this account already signed in through that
 			// provider once" without driving a whole round trip to establish it.
-			federated: user.federated
+			federated: user.federated,
+			// And seeding an enrolment is how a spec sets up "this account already holds an
+			// authenticator" without driving the enrolment flow — which is what lets the operator-side
+			// specs (clearing an enrolment) run without the interaction-side ones existing.
+			totp: user.totp
 		};
 		this.users.set(full._id, full);
 		return full;
@@ -114,6 +118,14 @@ export class UserStore implements UserStoreInstance {
 		const user = this.users.get(_id);
 		if (!user) return null;
 		Object.assign(user, patch, { updatedAt: new Date() });
+		// Converged with the MongoDB store, which translates the same shape into `$unset`: a key present
+		// with an undefined value means remove the field, not store an undefined one. Leaving the key
+		// behind here would make the two adapters disagree about what a cleared enrolment looks like.
+		for (const [field, value] of Object.entries(patch)) {
+			if (value === undefined) {
+				delete user[field as keyof User];
+			}
+		}
 		return user;
 	}
 

--- a/lib/adapters/modelTypes.ts
+++ b/lib/adapters/modelTypes.ts
@@ -18,6 +18,10 @@ import type { RegistrationAccessTokenPayloadType } from '../models/registration_
 import type { ReplayDetectionPayloadType } from '../models/replay_detection.js';
 import type { SessionPayloadType } from '../models/session.js';
 import type {
+	TotpAttemptPayload,
+	TotpEnrollmentPayload
+} from '../totp/types.js';
+import type {
 	VerificationChallengePayload,
 	VerificationResendPayload
 } from '../verification/types.js';
@@ -56,6 +60,8 @@ export interface ModelPayloadByName {
 	RegistrationAccessToken: RegistrationAccessTokenPayloadType;
 	ReplayDetection: ReplayDetectionPayloadType;
 	Session: SessionPayloadType;
+	TotpAttempt: TotpAttemptPayload;
+	TotpEnrollment: TotpEnrollmentPayload;
 	VerificationChallenge: VerificationChallengePayload;
 	VerificationResend: VerificationResendPayload;
 }

--- a/lib/adapters/mongodb/userBucketStore.ts
+++ b/lib/adapters/mongodb/userBucketStore.ts
@@ -18,7 +18,10 @@ function withDefaults(bucket: UserBucket | null): UserBucket | null {
 		// must keep doing so. `passwordLogin` in particular cannot be left undefined: it is read as a
 		// boolean, and undefined is falsy, which would close the password door on every existing bucket.
 		passwordLogin: bucket.passwordLogin ?? true,
-		federation: bucket.federation ?? []
+		federation: bucket.federation ?? [],
+		// Undefined is falsy, and "not required" is the right reading for a bucket written before the
+		// second factor existed — the mirror of the passwordLogin default above.
+		totpRequired: bucket.totpRequired ?? false
 	};
 }
 
@@ -35,6 +38,7 @@ export class UserBucketStore implements UserBucketStoreInstance {
 		registrationOpen?: boolean;
 		emailVerificationRequired?: boolean;
 		verificationMethod?: UserBucket['verificationMethod'];
+		totpRequired?: boolean;
 	}): Promise<UserBucket> {
 		const now = new Date();
 		const bucket: UserBucket = {
@@ -47,6 +51,7 @@ export class UserBucketStore implements UserBucketStoreInstance {
 			registrationOpen: data.registrationOpen ?? true,
 			emailVerificationRequired: data.emailVerificationRequired ?? false,
 			verificationMethod: data.verificationMethod ?? 'link',
+			totpRequired: data.totpRequired ?? false,
 			createdAt: now,
 			updatedAt: now
 		};
@@ -91,6 +96,7 @@ export class UserBucketStore implements UserBucketStoreInstance {
 				| 'registrationOpen'
 				| 'emailVerificationRequired'
 				| 'verificationMethod'
+				| 'totpRequired'
 			>
 		>
 	): Promise<UserBucket | null> {

--- a/lib/adapters/mongodb/userStore.ts
+++ b/lib/adapters/mongodb/userStore.ts
@@ -86,17 +86,39 @@ export class UserStore implements UserStoreInstance {
 		patch: Partial<
 			Pick<
 				User,
-				'roles' | 'active' | 'password' | 'verified' | 'claims' | 'federated'
+				| 'roles'
+				| 'active'
+				| 'password'
+				| 'verified'
+				| 'claims'
+				| 'federated'
+				| 'totp'
 			>
 		>
 	): Promise<User | null> {
-		return db
-			.collection<User>(this.collectionName)
-			.findOneAndUpdate(
-				{ _id },
-				{ $set: { ...patch, updatedAt: new Date() } },
-				{ returnDocument: 'after' }
-			);
+		/*
+		 * A key present with an undefined value means "remove this field", and `$set` cannot say that:
+		 * the driver drops undefined values by default, so clearing an enrolment through `$set` would
+		 * silently leave the secret in place — the account would still verify against an authenticator
+		 * the operator believes they revoked, with nothing failing anywhere to reveal it. Splitting the
+		 * patch is what makes `update(id, { totp: undefined })` mean what its one caller intends.
+		 */
+		const set: Record<string, unknown> = { updatedAt: new Date() };
+		const unset: Record<string, ''> = {};
+		for (const [field, value] of Object.entries(patch)) {
+			if (value === undefined) {
+				unset[field] = '';
+			} else {
+				set[field] = value;
+			}
+		}
+
+		return db.collection<User>(this.collectionName).findOneAndUpdate(
+			{ _id },
+			// An empty $unset is rejected by MongoDB, so the operator only appears when it has work.
+			Object.keys(unset).length ? { $set: set, $unset: unset } : { $set: set },
+			{ returnDocument: 'after' }
+		);
 	}
 
 	async destroy(_id: string): Promise<void> {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -25,6 +25,33 @@ export interface User {
 	 * needs to know the field exists.
 	 */
 	federated?: FederatedIdentity[];
+	/*
+	 * This account's authenticator, when it has one. Present ⇔ enrolled: there is deliberately no
+	 * separate `enrolled` boolean, because two fields claiming to say the same thing disagree after
+	 * the first edit. A secret that has been offered but not yet proved lives in the TotpEnrollment
+	 * area and never here.
+	 *
+	 * Embedded rather than given an area of its own, for exactly the reason `federated` is: the
+	 * account cascade destroys this row and bucket deletion destroys the whole area, so no cascade
+	 * arm needs to know the field exists.
+	 *
+	 * `secret` is recoverable by construction — TOTP verification is symmetric, so it cannot be
+	 * hashed the way a password is. It is therefore barred from every read surface instead:
+	 * `presentUser` in lib/admin/users-end/routes.ts removes it from every administrative read, and
+	 * test/mcp/secrecy.spec.ts sweeps every published read to keep that true. Nothing outside
+	 * lib/totp/ reads it.
+	 */
+	totp?: {
+		/* Base32, RFC 4648 §6. */
+		secret: string;
+		enrolledAt: Date;
+		/*
+		 * The time step of the most recently accepted code. A submitted code whose step is at or below
+		 * this is refused, which is what stops a code observed in flight being replayed for the rest of
+		 * its ~90-second acceptance band.
+		 */
+		lastStep: number;
+	};
 }
 
 export interface ModelAdapter<TPayload = unknown> {
@@ -170,7 +197,14 @@ export interface UserStoreInstance {
 		patch: Partial<
 			Pick<
 				User,
-				'roles' | 'active' | 'password' | 'verified' | 'claims' | 'federated'
+				| 'roles'
+				| 'active'
+				| 'password'
+				| 'verified'
+				| 'claims'
+				| 'federated'
+				/* Set when an enrolment is confirmed, and set back to undefined when an operator clears one. */
+				| 'totp'
 			>
 		>
 	): Promise<User | null>;
@@ -612,6 +646,25 @@ export interface UserBucket {
 	emailVerificationRequired: boolean;
 	// Which proof the registrant uses when verification is required.
 	verificationMethod: VerificationMethod;
+	/*
+	 * Whether a **password** sign-in to this bucket must also carry a one-time code from an
+	 * authenticator app. Defaulted `false` on read in both adapters, so a bucket document written
+	 * before this field existed keeps the behaviour it had.
+	 *
+	 * A boolean beside `passwordLogin` rather than an enum replacing it, deliberately. An enum
+	 * `'password' | 'password_totp'` would be a second field claiming to say whether the password
+	 * door is open — precisely the shape `passwordLogin` above warns about, and it disagrees with
+	 * `passwordLogin` the first time somebody edits one and not the other. As a boolean the two
+	 * compose: `passwordLogin` says whether the door exists, this says whether it needs two keys.
+	 *
+	 * Governs the password door only. Federated sign-in is never gated by it — the upstream provider
+	 * owns its own factor policy, exactly as `passwordLogin` governs password doors and federation
+	 * availability is derived per provider.
+	 *
+	 * Permitted, and inert, while `passwordLogin` is false. The admin route says so rather than
+	 * refusing: an operator recording intent ahead of opening the door is doing something reasonable.
+	 */
+	totpRequired: boolean;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -627,6 +680,7 @@ export interface UserBucketStoreInstance {
 		registrationOpen?: boolean;
 		emailVerificationRequired?: boolean;
 		verificationMethod?: VerificationMethod;
+		totpRequired?: boolean;
 	}): Promise<UserBucket>;
 	find(id: string): Promise<UserBucket | null>;
 	list(): Promise<UserBucket[]>;
@@ -644,6 +698,7 @@ export interface UserBucketStoreInstance {
 				| 'registrationOpen'
 				| 'emailVerificationRequired'
 				| 'verificationMethod'
+				| 'totpRequired'
 			>
 		>
 	): Promise<UserBucket | null>;

--- a/lib/admin/auth/login.ts
+++ b/lib/admin/auth/login.ts
@@ -190,8 +190,7 @@ export const adminLogin = new Elysia({ name: 'admin-login' })
 		cookie[ADMIN_SESSION_COOKIE].set(expiredSessionCookieAttributes());
 
 		const providerSessionId = cookie[cookieNames.session]?.value as
-			| string
-			| undefined;
+			string | undefined;
 		if (providerSessionId) {
 			const session = await findSession(providerSessionId);
 			if (session) await destroyProviderSession(session);

--- a/lib/admin/buckets/routes.ts
+++ b/lib/admin/buckets/routes.ts
@@ -44,6 +44,26 @@ function presentBucket<T extends Pick<UserBucket, 'federation'>>(bucket: T): T {
 	return { ...bucket, federation: presentAll(bucket) as T['federation'] };
 }
 
+/*
+ * A second factor on a bucket that accepts no passwords is inert, not wrong: the requirement governs
+ * the password door, and there is no password door. Recording the intended posture before opening one
+ * is a reasonable order to do things in, so this says so rather than refusing — a 422 here would make
+ * an operator turn password login on, set the flag, and turn it back off to express what they meant.
+ *
+ * Only on the write paths. A read that carried it would repeat the same sentence on every poll of a
+ * federation-only bucket, which trains an operator to ignore it.
+ */
+function withInertTotpAdvisory<
+	T extends Pick<UserBucket, 'totpRequired' | 'passwordLogin'>
+>(bucket: T): T | (T & { advisory: string }) {
+	if (!bucket.totpRequired || bucket.passwordLogin !== false) return bucket;
+	return {
+		...bucket,
+		advisory:
+			'totpRequired has no effect while passwordLogin is off — it governs password sign-in, and federated sign-in is never gated by it'
+	};
+}
+
 export const bucketRoutes = new Elysia({ name: 'admin-buckets' })
 	.use(resolveAdmin)
 	.onError(({ error, set }) => {
@@ -85,9 +105,12 @@ export const bucketRoutes = new Elysia({ name: 'admin-buckets' })
 				passwordLogin: body.passwordLogin,
 				registrationOpen: body.registrationOpen,
 				emailVerificationRequired: body.emailVerificationRequired,
-				verificationMethod: body.verificationMethod
+				verificationMethod: body.verificationMethod,
+				totpRequired: body.totpRequired
 			});
 			set.status = 201;
+			// No advisory is reachable here: the guard above proves a new bucket accepts passwords, so
+			// the requirement can never be inert at creation.
 			return presentBucket(bucket);
 		},
 		{ body: CreateBucketBody }
@@ -120,7 +143,7 @@ export const bucketRoutes = new Elysia({ name: 'admin-buckets' })
 			});
 			const updated = await getBucketStore().update(params.id, body);
 			if (!updated) throw new AdminError(404, 'bucket not found');
-			return updated && presentBucket(updated);
+			return withInertTotpAdvisory(presentBucket(updated));
 		},
 		{ body: UpdateBucketBody }
 	)

--- a/lib/admin/buckets/schema.ts
+++ b/lib/admin/buckets/schema.ts
@@ -14,7 +14,8 @@ export const CreateBucketBody = t.Object({
 	passwordLogin: t.Optional(t.Boolean()),
 	registrationOpen: t.Optional(t.Boolean()),
 	emailVerificationRequired: t.Optional(t.Boolean()),
-	verificationMethod: t.Optional(VerificationMethod)
+	verificationMethod: t.Optional(VerificationMethod),
+	totpRequired: t.Optional(t.Boolean())
 });
 
 export const UpdateBucketBody = t.Object({
@@ -24,5 +25,11 @@ export const UpdateBucketBody = t.Object({
 	passwordLogin: t.Optional(t.Boolean()),
 	registrationOpen: t.Optional(t.Boolean()),
 	emailVerificationRequired: t.Optional(t.Boolean()),
-	verificationMethod: t.Optional(VerificationMethod)
+	verificationMethod: t.Optional(VerificationMethod),
+	/*
+	 * Governs the password door only — a federated sign-in is never gated by it, because the upstream
+	 * provider owns its own factor policy. Accepted while `passwordLogin` is off, where it is inert;
+	 * the route says so rather than refusing.
+	 */
+	totpRequired: t.Optional(t.Boolean())
 });

--- a/lib/admin/ui/pages/BucketDetail.tsx
+++ b/lib/admin/ui/pages/BucketDetail.tsx
@@ -10,6 +10,7 @@ import {
 	Space,
 	Tag,
 	Typography,
+	Tooltip,
 	Popconfirm,
 	message
 } from 'antd';
@@ -18,7 +19,16 @@ import type { UserBucket, User } from '../../../adapters/types.js';
 import { FederationPanel } from './FederationPanel.js';
 import { UserIdentities } from './UserIdentities.js';
 
-type EndUser = Omit<User, 'password'>;
+/*
+ * What the API actually returns, which is not the stored record: `presentUser` removes the password
+ * hash and the authenticator secret, and substitutes the two derived facts an operator may see. Typed
+ * from that shape rather than from `User` so the console cannot accidentally reference a field the
+ * server does not send.
+ */
+type EndUser = Omit<User, 'password' | 'totp'> & {
+	totpEnrolled: boolean;
+	totpEnrolledAt: string | null;
+};
 
 interface CreateValues {
 	email: string;
@@ -55,6 +65,7 @@ export function BucketDetail({
 		registrationOpen?: boolean;
 		emailVerificationRequired?: boolean;
 		verificationMethod?: 'link' | 'code';
+		totpRequired?: boolean;
 	}>();
 
 	const roleOptions = (bucket?.roles ?? []).map((r) => ({
@@ -141,6 +152,23 @@ export function BucketDetail({
 		await load();
 	}
 
+	async function onClearTotp(uid: string) {
+		const res = await fetch(`${base}/users/${uid}/totp`, { method: 'DELETE' });
+		if (!res.ok) {
+			// The server's own reason where it gives one — a partial session sweep says which areas
+			// survived, and replacing that with a generic sentence would hide the half that matters.
+			const detail = (await res.json().catch(() => null)) as {
+				message?: string;
+			} | null;
+			message.error(detail?.message ?? 'failed to clear the authenticator');
+			return;
+		}
+		message.success(
+			'authenticator cleared — they will set up a new one at their next sign-in'
+		);
+		await load();
+	}
+
 	async function onSaveBucket(values: {
 		name: string;
 		roles?: string[];
@@ -148,6 +176,7 @@ export function BucketDetail({
 		registrationOpen?: boolean;
 		emailVerificationRequired?: boolean;
 		verificationMethod?: 'link' | 'code';
+		totpRequired?: boolean;
 	}) {
 		const res = await fetch(base, {
 			method: 'PATCH',
@@ -201,7 +230,8 @@ export function BucketDetail({
 								registrationOpen: bucket?.registrationOpen ?? true,
 								emailVerificationRequired:
 									bucket?.emailVerificationRequired ?? false,
-								verificationMethod: bucket?.verificationMethod ?? 'link'
+								verificationMethod: bucket?.verificationMethod ?? 'link',
+								totpRequired: bucket?.totpRequired ?? false
 							});
 							setBucketEditOpen(true);
 						}}
@@ -246,6 +276,26 @@ export function BucketDetail({
 						render: (v: boolean) => (v ? 'yes' : 'no')
 					},
 					{
+						// Whether there is an authenticator, and since when. Never the secret behind it —
+						// the server does not send it, to any role.
+						title: 'Authenticator',
+						dataIndex: 'totpEnrolled',
+						render: (enrolled: boolean, row: EndUser) =>
+							enrolled ? (
+								<Tooltip
+									title={
+										row.totpEnrolledAt
+											? `Enrolled ${new Date(row.totpEnrolledAt).toLocaleString()}`
+											: 'Enrolled'
+									}
+								>
+									<Tag color="green">enrolled</Tag>
+								</Tooltip>
+							) : (
+								<Tag>none</Tag>
+							)
+					},
+					{
 						title: 'Actions',
 						render: (_: unknown, row: EndUser) => (
 							<Space>
@@ -274,6 +324,19 @@ export function BucketDetail({
 								>
 									Identities
 								</Button>
+								{/* Offered only where there is something to clear, and stating the two
+								    consequences an operator cannot see from here: the old codes stop working,
+								    and the person is signed out everywhere. */}
+								{row.totpEnrolled && (
+									<Popconfirm
+										title="Clear this authenticator?"
+										description="Their current authenticator stops working immediately and they are signed out everywhere. They set up a new one at their next sign-in."
+										okText="Clear and sign out"
+										onConfirm={() => onClearTotp(row._id)}
+									>
+										<Button size="small">Clear authenticator</Button>
+									</Popconfirm>
+								)}
 								{/* The consequence, stated: deleting an account also ends the sessions and tokens
 								    it is currently using, which is the half an operator cannot see from here. */}
 								<Popconfirm
@@ -436,6 +499,19 @@ export function BucketDetail({
 						tooltip="Turn off for a bucket whose users must come from an identity provider. Refused unless this bucket has an enabled provider."
 					>
 						<Switch />
+					</Form.Item>
+					{/*
+					 * Disabled rather than hidden when password sign-in is off: the setting still exists and
+					 * still means something, and hiding it would leave an operator wondering where it went.
+					 * The server accepts it either way and returns the same explanation.
+					 */}
+					<Form.Item
+						name="totpRequired"
+						label="Require an authenticator app"
+						valuePropName="checked"
+						tooltip="Password sign-ins to this bucket must also carry a 6-digit code. Anyone without an authenticator sets one up at their next sign-in. Federated sign-in is not affected — the identity provider owns that policy."
+					>
+						<Switch disabled={bucket?.passwordLogin === false} />
 					</Form.Item>
 					<Form.Item
 						name="registrationOpen"

--- a/lib/admin/users-end/routes.ts
+++ b/lib/admin/users-end/routes.ts
@@ -15,7 +15,11 @@ import {
 	ResetPasswordBody
 } from './schema.js';
 import { recordAdminAudit } from '../audit/record.js';
-import { cascadeForAccount } from '../../helpers/cascade.js';
+import {
+	cascadeForAccount,
+	endSessionsForAccount
+} from '../../helpers/cascade.js';
+import { clearAttempts } from '../../totp/verify.js';
 import nanoid from '../../helpers/nanoid.js';
 
 function assertRolesSubset(
@@ -32,9 +36,32 @@ function assertRolesSubset(
 	}
 }
 
-const strip = (u: { password?: string }) => {
-	const { password: _password, ...safe } = u;
-	return safe;
+/*
+ * The one shape an end-user record takes on its way out of this server.
+ *
+ * Two fields never leave, and for different reasons. `password` is a hash nobody needs. `totp` is the
+ * shared secret behind an authenticator, and unlike a password it cannot be hashed — TOTP verification
+ * is symmetric, so the server has to hold something recoverable. That makes "it never appears in a
+ * read" the whole of its protection, and the protection has to live in one function rather than at
+ * each of the four call sites: a presenter somebody forgets on one route is exactly how every
+ * administrator came to be handed every bucket's federation secrets (lib/admin/buckets/routes.ts).
+ *
+ * What an operator legitimately needs — whether there is an authenticator, and since when — is derived
+ * here instead, so answering that question never involves handling the secret.
+ *
+ * test/mcp/secrecy.spec.ts sweeps every published read for exactly this.
+ */
+const presentUser = <
+	T extends { password?: string; totp?: { enrolledAt: Date } }
+>(
+	user: T
+) => {
+	const { password: _password, totp, ...safe } = user;
+	return {
+		...safe,
+		totpEnrolled: Boolean(totp),
+		totpEnrolledAt: totp?.enrolledAt?.toISOString() ?? null
+	};
 };
 
 export const endUserRoutes = new Elysia({ name: 'admin-users-end' })
@@ -49,7 +76,7 @@ export const endUserRoutes = new Elysia({ name: 'admin-users-end' })
 		const ctx = assertAuth(admin as AdminContext | null);
 		await loadBucketForUsers(ctx, params.id);
 		const users = await getUserStore(params.id).list();
-		return users.map(strip);
+		return users.map(presentUser);
 	})
 	.post(
 		'/admin/api/buckets/:id/users',
@@ -76,7 +103,7 @@ export const endUserRoutes = new Elysia({ name: 'admin-users-end' })
 				userId
 			);
 			set.status = 201;
-			return strip(user);
+			return presentUser(user);
 		},
 		{ body: CreateEndUserBody }
 	)
@@ -92,7 +119,7 @@ export const endUserRoutes = new Elysia({ name: 'admin-users-end' })
 			});
 			const updated = await getUserStore(params.id).update(params.uid, body);
 			if (!updated) throw new AdminError(404, 'user not found');
-			return strip(updated);
+			return presentUser(updated);
 		},
 		{ body: UpdateEndUserBody }
 	)
@@ -114,6 +141,49 @@ export const endUserRoutes = new Elysia({ name: 'admin-users-end' })
 			return { ok: true };
 		},
 		{ body: ResetPasswordBody }
+	)
+	/*
+	 * Recovery for a lost authenticator: clear the enrolment, and the account enrols afresh at its next
+	 * sign-in. Ordinary and audited rather than gated, because it is the *recovery* action — the harm it
+	 * undoes is someone permanently locked out, and what it costs is one re-enrolment.
+	 *
+	 * Deliberately a reset and not a deletion. Sessions go, because a session obtained with a factor the
+	 * account no longer holds must not outlive it; grants and tokens stay, because revoking a token is
+	 * not withdrawing consent (lib/helpers/cascade.ts states this boundary).
+	 *
+	 * Idempotent: clearing an account that holds no authenticator succeeds, and still records. An
+	 * operator should not have to know the current state to reach the one they want.
+	 */
+	.delete(
+		'/admin/api/buckets/:id/users/:uid/totp',
+		async ({ admin, params }) => {
+			const ctx = assertAuth(admin as AdminContext | null);
+			await loadBucketForUsers(ctx, params.id);
+
+			// Audit-first, as the password reset beside it is: a mutation is not reported successful
+			// unless its entry was recorded. No attribute names and no values — the act is the whole fact.
+			await recordAdminAudit(ctx, 'enduser.totp.clear', params.uid, {
+				targetScope: params.id
+			});
+
+			const updated = await getUserStore(params.id).update(params.uid, {
+				totp: undefined
+			});
+			if (!updated) throw new AdminError(404, 'user not found');
+
+			// So a re-enrolment does not begin inside a lockout the lost device earned.
+			await clearAttempts(params.id, params.uid);
+
+			const cascade = await endSessionsForAccount(params.uid);
+			if (cascade.failedAreas.length > 0) {
+				throw new AdminError(
+					500,
+					`the authenticator was cleared, but sessions survive in: ${cascade.failedAreas.join(', ')}`,
+					{ failedAreas: cascade.failedAreas }
+				);
+			}
+			return { ok: true };
+		}
 	)
 	.delete('/admin/api/buckets/:id/users/:uid', async ({ admin, params }) => {
 		const ctx = assertAuth(admin as AdminContext | null);

--- a/lib/consts/admin_audit_routes.ts
+++ b/lib/consts/admin_audit_routes.ts
@@ -157,6 +157,12 @@ const routes = [
 		targetType: 'EndUser'
 	},
 	{
+		action: 'enduser.totp.clear',
+		method: 'DELETE',
+		path: '/admin/api/buckets/:id/users/:uid/totp',
+		targetType: 'EndUser'
+	},
+	{
 		action: 'enduser.delete',
 		method: 'DELETE',
 		path: '/admin/api/buckets/:id/users/:uid',

--- a/lib/consts/storage_inventory.ts
+++ b/lib/consts/storage_inventory.ts
@@ -79,6 +79,8 @@ export const MODEL_AREAS = [
 	'RegistrationAccessToken',
 	'ReplayDetection',
 	'Session',
+	'TotpAttempt',
+	'TotpEnrollment',
 	'VerificationChallenge',
 	'VerificationResend'
 ] as const;
@@ -297,6 +299,24 @@ export const STORAGE_INVENTORY: readonly StorageArea[] = [
 	modelArea('Session', EXPIRES_AT, byAccount, [
 		{ key: { 'payload.uid': 1 }, unique: true }
 	]),
+	/*
+	 * The second factor's two areas, both account-owned, and neither is owned by convention.
+	 *
+	 * Their payloads name `accountId`, and the reverse ownership check in
+	 * test/storage_contract/inventory_drift.spec.ts fails any area whose payload holds an owner field
+	 * this table does not declare — the finding already recorded for FederationState above, and correct
+	 * for the same reason: such a record is one no cascade sweeps.
+	 *
+	 * Declaring them owned is also the better property in both cases. An outstanding enrolment offer
+	 * naming a deleted account dies with it rather than sitting on a secret for nobody, and a deleted
+	 * account's lockout window does not survive to greet an account later created under a reused id.
+	 *
+	 * Point-read by id in both cases — the enrolment by the interaction uid, the window by
+	 * `${bucketId}:${accountId}` — so neither needs an index beyond the expiry and owner ones
+	 * indexesFor() derives.
+	 */
+	modelArea('TotpAttempt', EXPIRES_AT, byAccount),
+	modelArea('TotpEnrollment', EXPIRES_AT, byAccount),
 	/*
 	 * Verification challenges and resend counters are written with a TTL and were never provisioned,
 	 * so before this table they auto-created on first write with no expiry index at all: expired

--- a/lib/interactions/index.ts
+++ b/lib/interactions/index.ts
@@ -95,9 +95,17 @@ function persistInteraction(interaction: {
 	payload: { exp?: number };
 	save(ttl: number): Promise<unknown>;
 }): Promise<unknown> {
-	return interaction.save(
-		(interaction.payload.exp ?? epochTime()) - epochTime()
-	);
+	const remaining = (interaction.payload.exp ?? epochTime()) - epochTime();
+	/*
+	 * Clamped, because both ends of the unclamped range write the wrong thing through
+	 * MongoAdapter.upsert: a TTL of exactly 0 is falsy there, so no `expiresAt` is written at all and
+	 * an interaction that should be seconds from death is instead left non-expiring; a negative one
+	 * back-dates `expiresAt` and kills the record mid-request. Both are reachable in the same narrow
+	 * window — an interaction that expires between the resolve step reading it and a handler saving it,
+	 * or one whose `exp` is somehow absent. One second is the same floor lib/totp/verify.ts uses when
+	 * it re-writes an attempt window for the same reason.
+	 */
+	return interaction.save(Math.max(1, remaining));
 }
 import { ApplicationConfig } from 'lib/configs/application.js';
 
@@ -558,6 +566,14 @@ export const ui = new Elysia()
 			const outcome = await confirmEnrollment(uid, body.code);
 
 			if (!outcome.ok) {
+				/*
+				 * The account went away between the offer and this submission. Not the enrolment page
+				 * again — there is nothing to enrol — and not an error banner either, which would invite
+				 * them to keep typing codes at a row that no longer exists.
+				 */
+				if (outcome.reason === 'gone') {
+					return Response.redirect(buildUILoginPath(uid), 303);
+				}
 				if (outcome.reason === 'expired') {
 					// A fresh secret rather than a dead form: the GET mints one.
 					return Response.redirect(buildUIPath(uid, 'totp/enroll'), 303);

--- a/lib/interactions/index.ts
+++ b/lib/interactions/index.ts
@@ -17,8 +17,15 @@ import { loginOptionsForClient } from './loginOptions.js';
 import {
 	consentServer,
 	loginServer,
-	registrationServer
+	registrationServer,
+	totpServer
 } from './serverRender.js';
+import { verifyForAccount } from 'lib/totp/verify.js';
+import {
+	confirm as confirmEnrollment,
+	offer as offerEnrollment
+} from 'lib/totp/enrollment.js';
+import { MAX_ATTEMPTS_PER_INTERACTION } from 'lib/totp/consts.js';
 import { AccessDenied, SessionNotFound } from 'lib/helpers/errors.js';
 import epochTime from '../helpers/epoch_time.js';
 import sessionHandler from 'lib/shared/session.js';
@@ -66,7 +73,32 @@ import {
 	registrationClosedPage,
 	registrationSendFailedPage
 } from './registrationPages.js';
-import { buildUILoginPath } from './buildUIPath.js';
+import { buildUILoginPath, buildUIPath } from './buildUIPath.js';
+
+/*
+ * The single answer to every failed code, whatever went wrong: a guess, a replay, an expired step, or a
+ * throttle. Written once so no future branch can accidentally be more informative than the others —
+ * which is the only way an attacker learns anything here.
+ */
+const INVALID_CODE = 'Invalid code';
+
+/*
+ * Save an interaction without changing when it expires.
+ *
+ * Not `interaction.persist()`, which reads for exactly this and cannot work: its guard tests
+ * `this.exp`, while the value lives at `this.payload.exp` (lib/models/base_model.ts), so it throws
+ * `persist can only be called on previously persisted Interactions` for every interaction that has in
+ * fact been persisted. It had no callers before this, which is why nothing noticed. Written the way
+ * lib/actions/authorization/resume.ts already writes it.
+ */
+function persistInteraction(interaction: {
+	payload: { exp?: number };
+	save(ttl: number): Promise<unknown>;
+}): Promise<unknown> {
+	return interaction.save(
+		(interaction.payload.exp ?? epochTime()) - epochTime()
+	);
+}
 import { ApplicationConfig } from 'lib/configs/application.js';
 
 async function resume(interaction, cookie) {
@@ -331,6 +363,36 @@ export const ui = new Elysia()
 					handOffTo: redirectUriOf(interaction)
 				});
 			}
+			/*
+			 * Last, after every refusal above. The order is the point: an inactive or unverified account
+			 * is turned away exactly as it was, so the second factor never becomes the step at which an
+			 * account reveals that it exists.
+			 */
+			const { totpRequired } = await loginOptionsForClient(clientId);
+			if (totpRequired) {
+				/*
+				 * `result` is deliberately NOT written here. That is the whole of "a correct password
+				 * alone establishes nothing": no session is created, no token is issued, and the
+				 * authorization request stays where it is until a code arrives.
+				 */
+				interaction.payload.secondFactor = {
+					accountId: user._id,
+					transient: body.remember === 'on',
+					attempts: 0
+				};
+				await persistInteraction(interaction);
+				/*
+				 * A redirect rather than a render, and that is forced rather than stylistic:
+				 * loginClient.tsx reads the page name out of window.location.pathname, so a code page
+				 * served at the login path hydrates into an empty root. The federated decline path
+				 * redirects for the same reason.
+				 */
+				return Response.redirect(
+					buildUIPath(uid, user.totp ? 'totp' : 'totp/enroll'),
+					303
+				);
+			}
+
 			interaction.payload.result = {
 				login: {
 					accountId: user._id,
@@ -346,6 +408,198 @@ export const ui = new Elysia()
 				remember: t.Optional(t.Literal('on'))
 			})
 		}
+	)
+	/*
+	 * The code step. Reached only with a `secondFactor` on the interaction, which is to say only after a
+	 * password this server accepted — there is no way to arrive here by guessing a URL.
+	 */
+	.get('ui/:uid/totp', async ({ params: { uid }, interaction }) => {
+		const pending = interaction.payload.secondFactor;
+		if (!pending) {
+			return Response.redirect(buildUILoginPath(uid), 303);
+		}
+		const bucketId = await resolveBucketForClient(clientIdOf(interaction));
+		const user = await getUserStore(bucketId).find(pending.accountId);
+		// Enrolment cleared between the password and now: send them to set one up rather than ask for a
+		// code from an authenticator they no longer have.
+		if (!user?.totp) {
+			return Response.redirect(buildUIPath(uid, 'totp/enroll'), 303);
+		}
+		return totpServer(uid, {
+			mode: 'verify',
+			handOffTo: redirectUriOf(interaction)
+		});
+	})
+	.post(
+		'ui/:uid/totp',
+		async ({ body, params: { uid }, interaction, cookie }) => {
+			const pending = interaction.payload.secondFactor;
+			if (!pending) {
+				return Response.redirect(buildUILoginPath(uid), 303);
+			}
+
+			const bucketId = await resolveBucketForClient(clientIdOf(interaction));
+			const refuse = () =>
+				totpServer(uid, {
+					mode: 'verify',
+					errorMessage: INVALID_CODE,
+					handOffTo: redirectUriOf(interaction)
+				});
+
+			if (pending.attempts >= MAX_ATTEMPTS_PER_INTERACTION) {
+				return refuse();
+			}
+
+			const outcome = await verifyForAccount(
+				bucketId,
+				pending.accountId,
+				body.code
+			);
+
+			if (!outcome.ok) {
+				if (outcome.reason === 'not_enrolled') {
+					return Response.redirect(buildUIPath(uid, 'totp/enroll'), 303);
+				}
+				interaction.payload.secondFactor = {
+					...pending,
+					attempts: pending.attempts + 1
+				};
+				await persistInteraction(interaction);
+				/*
+				 * One answer for every failure — wrong, replayed, and throttled alike. A distinct "too many
+				 * attempts" would confirm to someone guessing that the account is real and that their
+				 * guesses are landing, which is the whole of what they wanted to learn.
+				 */
+				return refuse();
+			}
+
+			interaction.payload.result = {
+				login: {
+					accountId: pending.accountId,
+					transient: pending.transient,
+					/*
+					 * Both values are registered in RFC 8176. This is what tells a relying party two factors
+					 * were used: resume.ts reads `amr` off the login result onto the session, and the ID
+					 * token takes it from there. A password-only sign-in is left carrying no `amr` at all,
+					 * so "otp is present" is the test, and nothing changes for a bucket that does not
+					 * require the factor.
+					 */
+					amr: ['pwd', 'otp']
+				}
+			};
+			delete interaction.payload.secondFactor;
+			return resume(interaction, cookie);
+		},
+		{ body: t.Object({ code: t.String() }) }
+	)
+	/*
+	 * The enrolment step, reached from two directions — a registration into a requiring bucket, and a
+	 * password sign-in by an account that holds no authenticator yet. One flow, because they are the
+	 * same act: neither the registrant nor the existing account has a second factor, and both need one
+	 * before their sign-in can complete.
+	 */
+	.get('ui/:uid/totp/enroll', async ({ params: { uid }, interaction }) => {
+		const pending = interaction.payload.secondFactor;
+		if (!pending) {
+			return Response.redirect(buildUILoginPath(uid), 303);
+		}
+
+		const clientId = clientIdOf(interaction);
+		const bucketId = await resolveBucketForClient(clientId);
+		const { totpRequired } = await loginOptionsForClient(clientId);
+		// Lowered while this person was mid-flow: there is nothing left to enrol for.
+		if (!totpRequired) {
+			return Response.redirect(buildUILoginPath(uid), 303);
+		}
+
+		const user = await getUserStore(bucketId).find(pending.accountId);
+		if (!user) {
+			return Response.redirect(buildUILoginPath(uid), 303);
+		}
+		if (user.totp) {
+			return Response.redirect(buildUIPath(uid, 'totp'), 303);
+		}
+
+		const bucket = await getBucketStore().find(bucketId);
+		const { otpauthUri, secretText } = await offerEnrollment(
+			uid,
+			user._id,
+			bucketId,
+			{ email: user.email, label: bucket?.name || 'the application' }
+		);
+
+		return totpServer(uid, {
+			mode: 'enroll',
+			otpauthUri,
+			secretText,
+			handOffTo: redirectUriOf(interaction)
+		});
+	})
+	.post(
+		'ui/:uid/totp/enroll',
+		async ({ body, params: { uid }, interaction, cookie }) => {
+			const pending = interaction.payload.secondFactor;
+			if (!pending) {
+				return Response.redirect(buildUILoginPath(uid), 303);
+			}
+
+			const clientId = clientIdOf(interaction);
+			const bucketId = await resolveBucketForClient(clientId);
+
+			/*
+			 * The per-interaction cap and no account window. The pending secret already expires on its
+			 * own, and an account-wide lockout here would let a stranger who knows an email stop a real
+			 * person from ever enrolling — the throttle would become the attack.
+			 */
+			if (pending.attempts >= MAX_ATTEMPTS_PER_INTERACTION) {
+				return Response.redirect(buildUIPath(uid, 'totp/enroll'), 303);
+			}
+
+			const outcome = await confirmEnrollment(uid, body.code);
+
+			if (!outcome.ok) {
+				if (outcome.reason === 'expired') {
+					// A fresh secret rather than a dead form: the GET mints one.
+					return Response.redirect(buildUIPath(uid, 'totp/enroll'), 303);
+				}
+				interaction.payload.secondFactor = {
+					...pending,
+					attempts: pending.attempts + 1
+				};
+				await persistInteraction(interaction);
+
+				const user = await getUserStore(bucketId).find(pending.accountId);
+				const bucket = await getBucketStore().find(bucketId);
+				// Re-offering through the same function is what puts the SAME secret back on the page.
+				const { otpauthUri, secretText } = await offerEnrollment(
+					uid,
+					pending.accountId,
+					bucketId,
+					{
+						email: user?.email ?? '',
+						label: bucket?.name || 'the application'
+					}
+				);
+				return totpServer(uid, {
+					mode: 'enroll',
+					errorMessage: INVALID_CODE,
+					otpauthUri,
+					secretText,
+					handOffTo: redirectUriOf(interaction)
+				});
+			}
+
+			interaction.payload.result = {
+				login: {
+					accountId: pending.accountId,
+					transient: pending.transient,
+					amr: ['pwd', 'otp']
+				}
+			};
+			delete interaction.payload.secondFactor;
+			return resume(interaction, cookie);
+		},
+		{ body: t.Object({ code: t.String() }) }
 	)
 	/*
 	 * Leg one of a federated sign-in. Declares its own `params` schema, and that is load-bearing rather than
@@ -574,6 +828,21 @@ export const ui = new Elysia()
 					// Delivery failed: the account exists but is unverified; invite a retry.
 					return registrationSendFailedPage();
 				}
+			}
+
+			/*
+			 * After the verification handling above, so the two requirements compose rather than one
+			 * replacing the other: a bucket that wants both sends the registrant to prove their address
+			 * now, and meets the authenticator at their first sign-in.
+			 */
+			if (bucket?.totpRequired) {
+				interaction.payload.secondFactor = {
+					accountId: user._id,
+					transient: false,
+					attempts: 0
+				};
+				await persistInteraction(interaction);
+				return Response.redirect(buildUIPath(uid, 'totp/enroll'), 303);
 			}
 
 			return Response.redirect(`/ui/${uid}/login`, 303);

--- a/lib/interactions/loginClient.tsx
+++ b/lib/interactions/loginClient.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react';
 import { LoginPage } from './loginPage.tsx';
 import { ConsentPage } from './consentPage.tsx';
 import { RegistrationPage } from './registration.tsx';
+import { TotpPage } from './totpPage.tsx';
 import { ZeroRuntime } from '../html/zeroRuntime.js';
 
 declare global {
@@ -62,6 +63,24 @@ hydrateRoot(
 						return (
 							<RegistrationPage
 								uid={calculateUid()}
+								{...props}
+							/>
+						);
+					case 'totp':
+						/*
+						 * Both `ui/:uid/totp` and `ui/:uid/totp/enroll` land here — the page name is the
+						 * fourth path segment, which is `totp` for both — so which of the two this is comes
+						 * from the props, never from the URL.
+						 *
+						 * `mode` is defaulted to the code page and the spread comes last, so the server's
+						 * value wins. Drop the spread and the enrolment page hydrates into the code page:
+						 * the QR and the secret disappear the instant React takes over, leaving a form that
+						 * asks for a code from an authenticator the person was never able to set up.
+						 */
+						return (
+							<TotpPage
+								uid={calculateUid()}
+								mode="verify"
 								{...props}
 							/>
 						);

--- a/lib/interactions/loginOptions.ts
+++ b/lib/interactions/loginOptions.ts
@@ -14,6 +14,16 @@ import { resolveBucketForClient } from '../admin/auth/resolveBucket.js';
 
 export interface LoginOptions {
 	passwordLogin: boolean;
+	/*
+	 * Whether a password sign-in to this bucket must also carry a one-time code. Resolved here with
+	 * everything else the password door needs, for the reason above: the login POST, the registration
+	 * POST and both enrolment routes all ask this question, and a second lookup path is exactly the
+	 * drift this module exists to prevent.
+	 *
+	 * Deliberately not rendered on the login page. Advertising the requirement before the password is
+	 * known would say something about the accounts in this bucket to anyone who asks.
+	 */
+	totpRequired: boolean;
 	/* Only what the page renders: an id to build the link from and a label to show. Never the credentials. */
 	providers: { id: string; displayName: string }[];
 }
@@ -26,6 +36,10 @@ export async function loginOptionsForBucket(
 		// Defaulted true for a bucket that predates the field, which the stores also do on read — belt and
 		// braces here because a falsy value would silently close the password door.
 		passwordLogin: bucket?.passwordLogin !== false,
+		// `=== true` exactly, the mirror of the line above: absent means not required, which is what a
+		// bucket predating the field must get, and what makes an unreadable bucket fail open on this
+		// rather than locking everyone out of a bucket nobody configured.
+		totpRequired: bucket?.totpRequired === true,
 		providers: enabledProviders(bucket).map((provider) => ({
 			id: provider.id,
 			displayName: provider.displayName

--- a/lib/interactions/serverRender.tsx
+++ b/lib/interactions/serverRender.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react';
 import { LoginPage } from './loginPage.js';
 import { ConsentPage } from './consentPage.js';
 import { RegistrationPage } from './registration.js';
+import { TotpPage } from './totpPage.js';
 import type { ConsentView } from './consentView.js';
 import { htmlResponse } from '../html/csp.js';
 import { versionedAsset } from '../html/versionedAsset.js';
@@ -123,6 +124,64 @@ export async function registrationServer(
 			)
 		);
 	// Neither submitted password reaches this document — not the markup, not the props (spec FR-011).
+	return htmlResponse(html, {
+		status: errorMessage ? 400 : 200,
+		handOffTo: options.handOffTo
+	});
+}
+
+export async function totpServer(
+	uid: string,
+	options: {
+		mode: 'verify' | 'enroll';
+		errorMessage?: string;
+		otpauthUri?: string;
+		secretText?: string;
+		handOffTo?: string;
+	}
+) {
+	const { mode, errorMessage, otpauthUri, secretText } = options;
+
+	let html = await htmlTeamplate.text();
+	html = html
+		.replace('/public/loginClient.js', versionedAsset('loginClient.js'))
+		.replace('/public/favicon.ico', versionedAsset('favicon.ico'))
+		.replace(
+			'<!--app-title-->',
+			mode === 'enroll' ? 'Set Up Authenticator' : 'Two-Step Verification'
+		)
+		.replace('<!--app-styles-->', styleLinks())
+		/*
+		 * `mode` must be here as well as in the render. It decides whether the page shows a QR at all, so
+		 * a props script that omitted it would hydrate the enrolment page into the code page — the QR and
+		 * the secret vanishing the moment React takes over, in a browser only, with nothing logged.
+		 */
+		.replace(
+			'<!--app-props-->',
+			propsScript({ uid, mode, errorMessage, otpauthUri, secretText })
+		)
+		.replace(
+			'<!--app-html-->',
+			renderToString(
+				<StrictMode>
+					<ZeroRuntime>
+						<TotpPage
+							uid={uid}
+							mode={mode}
+							errorMessage={errorMessage}
+							otpauthUri={otpauthUri}
+							secretText={secretText}
+						/>
+					</ZeroRuntime>
+				</StrictMode>
+			)
+		);
+	/*
+	 * The submitted code never comes back with the page, in the markup or the props — the same rule the
+	 * registration page follows for a password. The enrolment secret does reach the document, which is
+	 * unavoidable: enrolment is the act of showing it. It goes no further, and `Cache-Control: no-store`
+	 * on every response is what keeps it from being written down on the way.
+	 */
 	return htmlResponse(html, {
 		status: errorMessage ? 400 : 200,
 		handOffTo: options.handOffTo

--- a/lib/interactions/totpPage.tsx
+++ b/lib/interactions/totpPage.tsx
@@ -1,0 +1,180 @@
+import {
+	ExclamationCircleOutlined,
+	SafetyCertificateOutlined
+} from '@ant-design/icons';
+import { Button, Card, Flex, Form, Input, QRCode, Typography } from 'antd';
+import { buildUIPath } from './buildUIPath.js';
+import { versionedAsset } from '../html/versionedAsset.js';
+
+/*
+ * The second factor's one page, in two modes.
+ *
+ * One component rather than two because the enrolment step and the code step differ only in what sits
+ * above the same six-digit field, and because `loginClient.tsx` derives the page name from the URL path
+ * — both routes live under `ui/:uid/totp`, so both hydrate through the same arm and the mode has to
+ * travel in the props either way.
+ *
+ * Belongs to the antd shell family (wiki: interaction-page-families): it carries a form the user works
+ * in. That imposes the hydration contract — the server substitutes `<!--app-props-->` and the client
+ * arm spreads those props — and violating either half erases the server-rendered content in a browser
+ * only, with nothing logged.
+ */
+
+export interface TotpPageProps {
+	uid: string;
+	mode: 'verify' | 'enroll';
+	errorMessage?: string;
+	/* Enrol mode only. The QR's value; carries the secret. */
+	otpauthUri?: string;
+	/* Enrol mode only. The same secret as text, grouped in fours. */
+	secretText?: string;
+}
+
+function ErrorBanner({ message }: { message: string }) {
+	return (
+		<Form.Item>
+			<div
+				style={{
+					padding: '12px 16px',
+					borderRadius: '6px',
+					border: '1px solid #ffccc7',
+					backgroundColor: '#fff2f0',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '8px'
+				}}
+			>
+				<span style={{ color: '#ff4d4f', fontSize: '14px' }}>
+					<ExclamationCircleOutlined />
+				</span>
+				<span style={{ color: '#ff4d4f', fontSize: '14px' }}>{message}</span>
+			</div>
+		</Form.Item>
+	);
+}
+
+export function TotpPage({
+	uid,
+	mode,
+	errorMessage,
+	otpauthUri,
+	secretText
+}: TotpPageProps) {
+	const enrolling = mode === 'enroll';
+	const action = buildUIPath(uid, enrolling ? 'totp/enroll' : 'totp');
+
+	return (
+		<Flex
+			justify="center"
+			style={{
+				display: 'flex',
+				height: '100vh',
+				alignItems: 'center',
+				backgroundColor: '#f0f2f5'
+			}}
+		>
+			<Card
+				style={{
+					width: 400,
+					padding: 24,
+					borderRadius: 12,
+					boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)'
+				}}
+			>
+				<div style={{ textAlign: 'center', marginBottom: 24 }}>
+					<img
+						src={versionedAsset('logo.svg')}
+						alt="Logo"
+						style={{ width: 120 }}
+					/>
+					<h2>
+						{enrolling ? 'Set up your authenticator' : 'Two-step verification'}
+					</h2>
+					<Typography.Text
+						type="secondary"
+						style={{ fontSize: 13 }}
+					>
+						{enrolling
+							? 'Scan this with an authenticator app, then enter the code it shows.'
+							: 'Enter the current code from your authenticator app.'}
+					</Typography.Text>
+				</div>
+
+				{enrolling && otpauthUri && (
+					<Flex
+						vertical
+						align="center"
+						gap={12}
+						style={{ marginBottom: 20 }}
+					>
+						{/*
+						 * `type="svg"`, not the default canvas: a canvas renders empty on the server and is
+						 * only drawn after hydration, so the QR would be missing for the whole first paint
+						 * and entirely absent to anything that does not run scripts.
+						 */}
+						<QRCode
+							type="svg"
+							value={otpauthUri}
+							size={180}
+						/>
+						{/*
+						 * The real fallback, not a nicety. A camera that will not focus, an app with no
+						 * scanner, a screen being read remotely — all of them come down to typing the secret,
+						 * so it is shown in full rather than hidden behind a "can't scan?" toggle.
+						 */}
+						<Typography.Text
+							type="secondary"
+							style={{ fontSize: 12 }}
+						>
+							Or enter this key manually:
+						</Typography.Text>
+						<Typography.Text
+							code
+							copyable={{ text: secretText?.replace(/\s+/g, '') }}
+							style={{ fontSize: 13, letterSpacing: 1 }}
+						>
+							{secretText}
+						</Typography.Text>
+					</Flex>
+				)}
+
+				<Form
+					name="totp"
+					method="post"
+					action={action}
+					onFinish={() => {
+						document.forms.namedItem('totp')?.submit();
+					}}
+				>
+					{errorMessage && <ErrorBanner message={errorMessage} />}
+					<Form.Item
+						name="code"
+						rules={[{ required: true, message: 'Please enter your code!' }]}
+					>
+						<Input
+							name="code"
+							prefix={<SafetyCertificateOutlined />}
+							placeholder="000000"
+							// A phone keypad rather than a full keyboard, and the browser's own one-time-code
+							// autofill where the platform offers it.
+							inputMode="numeric"
+							autoComplete="one-time-code"
+							autoFocus
+							maxLength={8}
+							style={{ letterSpacing: 4 }}
+						/>
+					</Form.Item>
+					<Form.Item>
+						<Button
+							type="primary"
+							htmlType="submit"
+							block
+						>
+							{enrolling ? 'Confirm' : 'Verify'}
+						</Button>
+					</Form.Item>
+				</Form>
+			</Card>
+		</Flex>
+	);
+}

--- a/lib/mcp/catalogue.ts
+++ b/lib/mcp/catalogue.ts
@@ -500,7 +500,7 @@ const catalogue = [
 		querySchema: null,
 		pathParams: [],
 		summary:
-			'Create a user bucket. A bucket cannot be created unreachable: at creation it has no providers, so password login cannot be switched off.'
+			'Create a user bucket. A bucket cannot be created unreachable: at creation it has no providers, so password login cannot be switched off. `totpRequired` makes a password sign-in also require a one-time code from an authenticator app; it governs password sign-in only and never gates a federated one.'
 	},
 	{
 		tool: 'bucket_update',
@@ -513,7 +513,7 @@ const catalogue = [
 		querySchema: null,
 		pathParams: ['id'],
 		summary:
-			"Change a bucket's name, roles, managers, or its registration and verification settings. Editing the bucket entity needs manager access to the bucket itself, not merely to a project it backs."
+			"Change a bucket's name, roles, managers, or its registration, verification and second-factor settings. Editing the bucket entity needs manager access to the bucket itself, not merely to a project it backs. `totpRequired` governs password sign-in only — it is accepted but inert while `passwordLogin` is off, and it never gates a federated sign-in, so it is not a way to secure a bucket that signs in through an upstream provider."
 	},
 
 	/* ----------------------------------------------- writes: end-users (4) */
@@ -541,6 +541,24 @@ const catalogue = [
 		pathParams: ['id', 'uid'],
 		summary:
 			"Change an end-user's email, roles, active state, or claims. Deactivating is a sign-in decision, not a deletion."
+	},
+	{
+		tool: 'bucket_user_totp_clear',
+		method: 'DELETE',
+		path: '/admin/api/buckets/:id/users/:uid/totp',
+		action: 'enduser.totp.clear',
+		/*
+		 * Ordinary rather than gated. The confirmation gate is for what cannot be undone; this is the
+		 * undoing — the state it repairs is a person locked out of their own account, and its cost is one
+		 * re-enrolment at their next sign-in.
+		 */
+		consequence: 'ordinary',
+		requiredRole: null,
+		bodySchema: null,
+		querySchema: null,
+		pathParams: ['id', 'uid'],
+		summary:
+			"Clear an end-user's authenticator enrolment. Their existing authenticator stops working at once and their sessions end; they set a new one up at their next sign-in. Use when someone has lost the device holding their codes. Their password, grants and tokens are untouched."
 	},
 	{
 		tool: 'bucket_user_password_reset',

--- a/lib/models/interaction.ts
+++ b/lib/models/interaction.ts
@@ -22,6 +22,25 @@ export const InteractionPayload = t.Composite([
 		cid: t.Optional(t.String()),
 		deviceCode: t.Optional(t.String()),
 		parJti: t.Optional(t.String()),
+		/*
+		 * A sign-in that has passed the password and not yet the second factor. Declared rather than
+		 * folded into the freeform `lastSubmission`, because a state that gates authentication should be
+		 * visible in the model instead of inferred from an unknown blob.
+		 *
+		 * Its presence is what stops the sign-in completing: the login POST writes this *instead of*
+		 * `result` when the bucket requires a code, and only the code POST turns it into a `result`.
+		 * Living on the interaction gives it the interaction's own TTL, so a half-finished sign-in
+		 * expires with the attempt it belongs to and needs no expiry logic of its own.
+		 */
+		secondFactor: t.Optional(
+			t.Object({
+				accountId: t.String(),
+				/* The "remember me" choice, carried across the code step so it is not lost. */
+				transient: t.Optional(t.Boolean()),
+				/* Wrong codes in this attempt. The per-account window lives in the TotpAttempt area. */
+				attempts: t.Number()
+			})
+		),
 		result: t.Optional(t.Unknown())
 	})
 ]);

--- a/lib/shared/destroy_session.ts
+++ b/lib/shared/destroy_session.ts
@@ -26,13 +26,7 @@ export async function backchannelLogoutFor(
 				back.push(
 					client.backchannelLogout(accountId, sid).then(
 						() => {
-							eventBus.emit(
-								'backchannel.success',
-								ctx,
-								client,
-								accountId,
-								sid
-							);
+							eventBus.emit('backchannel.success', ctx, client, accountId, sid);
 						},
 						(err) => {
 							eventBus.emit(

--- a/lib/totp/base32.ts
+++ b/lib/totp/base32.ts
@@ -1,0 +1,59 @@
+/*
+ * Base32 as RFC 4648 §6 defines it, unpadded.
+ *
+ * Unpadded because the only consumer is an `otpauth://` URI and a person retyping the secret from a
+ * screen: every authenticator app accepts an unpadded secret, and a trailing run of '=' in a query
+ * string is one more thing to percent-encode for no benefit. The decoder still accepts padding, so a
+ * secret pasted from somewhere else is not refused for a difference that carries no information.
+ */
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+export function encodeBase32(bytes: Buffer): string {
+	let out = '';
+	let value = 0;
+	let bits = 0;
+
+	for (const byte of bytes) {
+		value = (value << 8) | byte;
+		bits += 8;
+		while (bits >= 5) {
+			out += ALPHABET[(value >>> (bits - 5)) & 31];
+			bits -= 5;
+		}
+	}
+
+	// The final partial group is left-aligned into five bits, which is what padding would have covered.
+	if (bits > 0) {
+		out += ALPHABET[(value << (5 - bits)) & 31];
+	}
+
+	return out;
+}
+
+export function decodeBase32(text: string): Buffer {
+	// Whitespace and case are both artifacts of how the secret was shown, never of what it is: the
+	// enrolment page prints it grouped in fours, and a person retyping it may lowercase it.
+	const clean = text
+		.replace(/[\s-]+/g, '')
+		.replace(/=+$/, '')
+		.toUpperCase();
+	const out: number[] = [];
+	let value = 0;
+	let bits = 0;
+
+	for (const character of clean) {
+		const index = ALPHABET.indexOf(character);
+		if (index === -1) {
+			throw new TypeError(`not a base32 character: ${character}`);
+		}
+		value = (value << 5) | index;
+		bits += 5;
+		if (bits >= 8) {
+			out.push((value >>> (bits - 8)) & 255);
+			bits -= 8;
+		}
+	}
+
+	return Buffer.from(out);
+}

--- a/lib/totp/code.ts
+++ b/lib/totp/code.ts
@@ -1,0 +1,90 @@
+import crypto from 'node:crypto';
+
+import { DIGITS, DRIFT_STEPS, STEP_SECONDS } from './consts.js';
+
+/*
+ * HOTP (RFC 4226) and TOTP (RFC 6238), and nothing else. No clock, no storage, no I/O — the time is
+ * an argument, which is what makes the RFC 6238 Appendix B vectors testable with no fake clock and no
+ * injected time source (test/totp/algorithm.spec.ts).
+ *
+ * HMAC-SHA1 rather than SHA-256, deliberately, and this is the one deviation this module makes from
+ * "prefer the stronger primitive". RFC 6238 §1.2 permits SHA-1, SHA-256 and SHA-512, and the
+ * `algorithm=` parameter of the otpauth:// URI exists to say which — but Google Authenticator and
+ * several other widely deployed apps ignore that parameter and assume SHA-1 unconditionally. An
+ * enrolment those apps silently compute the wrong codes for is a failed enrolment, and the person
+ * cannot tell why. The choice costs nothing in strength: HMAC's security does not rest on the
+ * collision resistance of its hash, which is the property SHA-1 lost.
+ */
+
+/* RFC 4226 §5.3 — HMAC over the 8-byte big-endian counter, dynamic truncation, decimal, zero-padded. */
+export function hotp(
+	secret: Buffer,
+	counter: number,
+	digits: number = DIGITS
+): string {
+	const message = Buffer.alloc(8);
+	message.writeBigUInt64BE(BigInt(counter));
+
+	const digest = crypto.createHmac('sha1', secret).update(message).digest();
+
+	// The low four bits of the last byte choose where the four-byte window starts.
+	const offset = digest[digest.length - 1] & 0x0f;
+	const truncated =
+		((digest[offset] & 0x7f) << 24) |
+		((digest[offset + 1] & 0xff) << 16) |
+		((digest[offset + 2] & 0xff) << 8) |
+		(digest[offset + 3] & 0xff);
+
+	return (truncated % 10 ** digits).toString().padStart(digits, '0');
+}
+
+/* RFC 6238 §4 — the counter for a moment in time. */
+export function stepFor(unixSeconds: number): number {
+	return Math.floor(unixSeconds / STEP_SECONDS);
+}
+
+function equals(a: string, b: string): boolean {
+	const left = Buffer.from(a, 'ascii');
+	const right = Buffer.from(b, 'ascii');
+	// timingSafeEqual throws on a length mismatch, and a length difference is not secret anyway.
+	if (left.length !== right.length) return false;
+	return crypto.timingSafeEqual(left, right);
+}
+
+/*
+ * Whether `code` is valid for `secret` at `unixSeconds`, within the drift band.
+ *
+ * Returns the **step it matched**, not a boolean, and that is load-bearing: the caller records it
+ * against the account so the same code cannot be accepted twice while it is still nominally current
+ * (lib/totp/verify.ts). A `verify(): boolean` shape cannot express that guard, and retrofitting it
+ * would mean changing every call site.
+ *
+ * `after` refuses any step at or below it — the replay guard, expressed here so both the standing
+ * enrolment and any future caller get it from one place.
+ */
+export function verifyAt(
+	secret: Buffer,
+	code: string,
+	unixSeconds: number,
+	opts: { after?: number; digits?: number; driftSteps?: number } = {}
+): number | null {
+	const digits = opts.digits ?? DIGITS;
+	const drift = opts.driftSteps ?? DRIFT_STEPS;
+
+	// Authenticator apps display `123 456`; the space is presentation, not input.
+	const submitted = code.replace(/\s+/g, '');
+	if (!new RegExp(`^[0-9]{${digits}}$`).test(submitted)) {
+		return null;
+	}
+
+	const current = stepFor(unixSeconds);
+	for (let step = current - drift; step <= current + drift; step += 1) {
+		if (step < 0) continue;
+		if (opts.after !== undefined && step <= opts.after) continue;
+		if (equals(hotp(secret, step, digits), submitted)) {
+			return step;
+		}
+	}
+
+	return null;
+}

--- a/lib/totp/consts.ts
+++ b/lib/totp/consts.ts
@@ -1,0 +1,40 @@
+// Tunable bounds for the end-user second-factor flow. Kept in one place so the algorithm, the
+// enrolment lifecycle, the rate limiter and the tests share a single source of truth — the
+// arrangement lib/verification/consts.ts settled on.
+
+// RFC 6238 §4 default time step. Every widely deployed authenticator app assumes it, and the
+// `period=` parameter of the otpauth:// URI is as widely ignored as `algorithm=`.
+export const STEP_SECONDS = 30;
+
+// RFC 4226 §5.3 truncation length. Six is what an authenticator app displays.
+export const DIGITS = 6;
+
+// Steps either side of the current one that are still accepted, tolerating ordinary clock drift.
+// RFC 6238 §5.2 calls one step "a good balance"; a wider band multiplies the guess space linearly
+// for no gain, because the replay guard already caps how long any single code stays usable.
+export const DRIFT_STEPS = 1;
+
+// How long an offered-but-unconfirmed enrolment secret survives. Matches the verification flow's
+// CODE_TTL_SECONDS: an enrolment is a single sitting, and a secret nobody proved should not outlive it.
+export const ENROLLMENT_TTL_SECONDS = 15 * 60;
+
+// Failed code entries tolerated within one sign-in attempt before it refuses further submissions.
+// Matches lib/verification/consts.ts CODE_MAX_ATTEMPTS.
+export const MAX_ATTEMPTS_PER_INTERACTION = 5;
+
+/*
+ * Failed entries tolerated per account across sign-in attempts, within ACCOUNT_WINDOW_SECONDS.
+ *
+ * The per-interaction cap alone is defeated by starting a new interaction, which costs an attacker
+ * one request. With DRIFT_STEPS = 1 there are 3 acceptable codes out of 10^6 at any moment, so 10
+ * guesses per window is a ~3-in-10^5 chance of landing one — the arithmetic is written down here so
+ * it can be re-checked if either number moves.
+ */
+export const ACCOUNT_FAILURE_CAP = 10;
+
+// The rolling window the per-account cap is measured over, and the TTL of the record holding it.
+export const ACCOUNT_WINDOW_SECONDS = 15 * 60;
+
+// RFC 4226 §4 R6 recommends at least 128 bits and 160 for HMAC-SHA1; 160 is also what every
+// published test vector uses. Base32-encodes to 32 characters, which a person can retype.
+export const SECRET_BYTES = 20;

--- a/lib/totp/enrollment.ts
+++ b/lib/totp/enrollment.ts
@@ -1,0 +1,138 @@
+import crypto from 'node:crypto';
+
+import { adapter, getUserStore } from '../adapters/index.js';
+import epochTime from '../helpers/epoch_time.js';
+import { decodeBase32, encodeBase32 } from './base32.js';
+import { verifyAt } from './code.js';
+import {
+	DIGITS,
+	ENROLLMENT_TTL_SECONDS,
+	SECRET_BYTES,
+	STEP_SECONDS
+} from './consts.js';
+import type { TotpEnrollmentPayload } from './types.js';
+
+/*
+ * The lifecycle of a secret that has been offered but not yet proved.
+ *
+ * Records are keyed by the **interaction uid**, which decides three things at once. There is no
+ * enrolment handle to put in a hidden form field, so none to leak or to guess. An enrolment can only be
+ * completed from inside the interaction that started it, without a single ownership check. And a reload
+ * or a wrong code re-reads the same record, so the same secret stays on screen — a fresh one per request
+ * would mean a person who mistyped a digit has to delete and re-add the entry in their app.
+ *
+ * Nothing here writes to the account until a code proves possession, so an abandoned enrolment leaves
+ * the account exactly as it was.
+ */
+
+function enrollments() {
+	return adapter('TotpEnrollment');
+}
+
+/*
+ * The URI the QR encodes. The label is the bucket's name — the same value the verification mail uses to
+ * say who is asking — so an authenticator app lists the entry under something the person recognises.
+ *
+ * `algorithm`, `digits` and `period` are stated even though several widely deployed apps ignore them
+ * and assume exactly these values: the apps that do read them are then correct, and the ones that do
+ * not are correct by coincidence. Every component is encoded, because the label comes from operator
+ * input and an account is an email address.
+ */
+export function otpauthUriFor(
+	email: string,
+	label: string,
+	secret: string
+): string {
+	const account = `${encodeURIComponent(label)}:${encodeURIComponent(email)}`;
+	const query = new URLSearchParams({
+		secret,
+		issuer: label,
+		algorithm: 'SHA1',
+		digits: String(DIGITS),
+		period: String(STEP_SECONDS)
+	});
+	return `otpauth://totp/${account}?${query.toString()}`;
+}
+
+/* Grouped in fours: this is read off a screen and retyped, and an unbroken 32-character run is not. */
+export function groupSecret(secret: string): string {
+	return (secret.match(/.{1,4}/g) ?? []).join(' ');
+}
+
+export interface Offer {
+	secret: string;
+	otpauthUri: string;
+	secretText: string;
+}
+
+/*
+ * The secret on offer for this interaction — created on the first call, and the *same one* on every
+ * later call until it is confirmed or expires.
+ */
+export async function offer(
+	uid: string,
+	accountId: string,
+	bucketId: string,
+	{ email, label }: { email: string; label: string }
+): Promise<Offer> {
+	const existing = (await enrollments().find(uid)) as
+		TotpEnrollmentPayload | undefined;
+
+	// Compared rather than left to the store: MongoDB's TTL monitor deletes lazily, so an expired
+	// record can still be found for a while — the departure lib/password_reset/challenge.ts makes for
+	// the same reason, and it matters more here because this secret becomes a standing credential.
+	const live = existing && existing.exp > epochTime() ? existing : undefined;
+
+	const secret = live?.secret ?? encodeBase32(crypto.randomBytes(SECRET_BYTES));
+
+	if (!live) {
+		const exp = epochTime() + ENROLLMENT_TTL_SECONDS;
+		await enrollments().upsert(
+			uid,
+			{ accountId, bucketId, secret, exp },
+			ENROLLMENT_TTL_SECONDS
+		);
+	}
+
+	return {
+		secret,
+		otpauthUri: otpauthUriFor(email, label, secret),
+		secretText: groupSecret(secret)
+	};
+}
+
+export type ConfirmOutcome =
+	{ ok: true } | { ok: false; reason: 'expired' | 'invalid' };
+
+/*
+ * Turn a proved secret into the account's enrolment.
+ *
+ * `expired` is distinguished from `invalid` for the caller alone — one routes to a fresh secret, the
+ * other re-renders the page that is already on screen. Both reach the person as the same words.
+ */
+export async function confirm(
+	uid: string,
+	code: string
+): Promise<ConfirmOutcome> {
+	const pending = (await enrollments().find(uid)) as
+		TotpEnrollmentPayload | undefined;
+	if (!pending || pending.exp <= epochTime()) {
+		return { ok: false, reason: 'expired' };
+	}
+
+	const step = verifyAt(decodeBase32(pending.secret), code, epochTime());
+	if (step === null) {
+		return { ok: false, reason: 'invalid' };
+	}
+
+	/*
+	 * `lastStep` starts at the step just proved, not at zero: the code that completed the enrolment is
+	 * spent, and a person who submits it once more within the same 30 seconds — a double-submitted form,
+	 * or someone who watched them type it — must not be able to use it to sign in.
+	 */
+	await getUserStore(pending.bucketId).update(pending.accountId, {
+		totp: { secret: pending.secret, enrolledAt: new Date(), lastStep: step }
+	});
+	await enrollments().destroy(uid);
+	return { ok: true };
+}

--- a/lib/totp/enrollment.ts
+++ b/lib/totp/enrollment.ts
@@ -102,13 +102,15 @@ export async function offer(
 }
 
 export type ConfirmOutcome =
-	{ ok: true } | { ok: false; reason: 'expired' | 'invalid' };
+	{ ok: true } | { ok: false; reason: 'expired' | 'invalid' | 'gone' };
 
 /*
  * Turn a proved secret into the account's enrolment.
  *
- * `expired` is distinguished from `invalid` for the caller alone — one routes to a fresh secret, the
- * other re-renders the page that is already on screen. Both reach the person as the same words.
+ * The three refusals are distinguished for the caller alone, because each needs a different next
+ * page: `expired` routes to a fresh secret, `invalid` re-renders the page already on screen, and
+ * `gone` sends them back to the login door. Only the first two reach a person, and they reach them
+ * as the same words.
  */
 export async function confirm(
 	uid: string,
@@ -130,9 +132,26 @@ export async function confirm(
 	 * spent, and a person who submits it once more within the same 30 seconds — a double-submitted form,
 	 * or someone who watched them type it — must not be able to use it to sign in.
 	 */
-	await getUserStore(pending.bucketId).update(pending.accountId, {
-		totp: { secret: pending.secret, enrolledAt: new Date(), lastStep: step }
-	});
+	const enrolled = await getUserStore(pending.bucketId).update(
+		pending.accountId,
+		{
+			totp: { secret: pending.secret, enrolledAt: new Date(), lastStep: step }
+		}
+	);
+	/*
+	 * The write is the enrolment; reporting success without it would hand the caller a completed
+	 * second factor for an account that holds none — and, because the caller then writes
+	 * `result.login`, sign a person in as an account that no longer exists. `update` returns null for
+	 * exactly one reason: the row is gone, deleted between the offer and this confirmation.
+	 *
+	 * The pending record goes either way. There is nothing left to enrol into, so leaving it would
+	 * only keep a live secret addressed to a dead account until its TTL caught up.
+	 */
+	if (!enrolled) {
+		await enrollments().destroy(uid);
+		return { ok: false, reason: 'gone' };
+	}
+
 	await enrollments().destroy(uid);
 	return { ok: true };
 }

--- a/lib/totp/types.ts
+++ b/lib/totp/types.ts
@@ -1,0 +1,48 @@
+import { Type as t, type Static } from '@sinclair/typebox';
+
+// TypeBox schemas rather than plain interfaces, for the reason lib/verification/types.ts states in
+// full: the storage-ownership drift guard reads an area's payload fields at runtime, and an
+// interface erases. Both payloads name `accountId`, which is one of the fields a deleted account's
+// cascade sweeps — so the inventory must declare both areas account-owned, and the guard's reverse
+// check is what makes that mandatory rather than optional.
+//
+// The records are written straight through `adapter('TotpEnrollment')` / `adapter('TotpAttempt')`
+// and never through a model class, so nothing validates them against these schemas — they exist to
+// be introspected, not to gate a write.
+
+/*
+ * A secret that has been offered to a person but not yet proved. Keyed by the **interaction uid**,
+ * which is what makes it reachable only from inside the interaction that started it: there is no
+ * enrolment handle in a form field to leak or guess, and a refresh or a wrong code re-reads the same
+ * record and therefore re-offers the same secret. A fresh secret on every wrong code would mean a
+ * person who mistyped a digit has to delete and re-add the entry in their authenticator app.
+ *
+ * `exp` mirrors the adapter's expiry (epoch seconds) and is asserted by the test adapter.
+ */
+export const TotpEnrollmentPayload = t.Object({
+	accountId: t.String(),
+	bucketId: t.String(),
+	// Base32. Never reaches `user.totp` without a correct code, and never reaches a log or an audit entry.
+	secret: t.String(),
+	exp: t.Number()
+});
+
+export type TotpEnrollmentPayload = Static<typeof TotpEnrollmentPayload>;
+
+/*
+ * The per-account failure window, keyed by `${bucketId}:${accountId}`.
+ *
+ * Separate from the per-interaction counter on the Interaction record because the two limit
+ * different things: a counter that lived only on the interaction is defeated by starting a new one,
+ * which costs an attacker a single request.
+ *
+ * Written only on a failure, so an account that never fails leaves nothing behind.
+ */
+export const TotpAttemptPayload = t.Object({
+	accountId: t.String(),
+	failures: t.Number(),
+	windowStart: t.Number(),
+	exp: t.Number()
+});
+
+export type TotpAttemptPayload = Static<typeof TotpAttemptPayload>;

--- a/lib/totp/verify.ts
+++ b/lib/totp/verify.ts
@@ -1,0 +1,96 @@
+import { adapter, getUserStore } from '../adapters/index.js';
+import epochTime from '../helpers/epoch_time.js';
+import { decodeBase32 } from './base32.js';
+import { verifyAt } from './code.js';
+import { ACCOUNT_FAILURE_CAP, ACCOUNT_WINDOW_SECONDS } from './consts.js';
+import type { TotpAttemptPayload } from './types.js';
+
+/*
+ * Verification against a standing enrolment, with both things that make a six-digit secret survivable:
+ * the replay guard and the per-account failure window.
+ *
+ * The window arithmetic is written here rather than taken from lib/helpers/rate_window.ts, and that is
+ * a decision rather than an oversight. That helper exists because "how often may one address be made to
+ * receive a security email" is a security rule with two callers, and its own comment is explicit that
+ * only the arithmetic is shared while the bounds and storage stay with each flow. What is shared with
+ * this flow is narrower still — a rolling window and a cap, three lines — while its record shape
+ * (`lastSentAt`, `dayCount`) and its refusal vocabulary (`cooldown` | `daily`) describe sends. Counting
+ * failed codes in fields named after sends, with a cooldown pinned to zero to disable a concept this
+ * flow does not have, would make both callers harder to read in exchange for no shared rule.
+ */
+
+function attempts() {
+	return adapter('TotpAttempt');
+}
+
+/* Addressed, never scanned for — the account cascade destroys it by computed id. */
+export function attemptKey(bucketId: string, accountId: string): string {
+	return `${bucketId}:${accountId}`;
+}
+
+export type Outcome =
+	| { ok: true }
+	| { ok: false; reason: 'invalid' | 'throttled' | 'not_enrolled' };
+
+/*
+ * `throttled` and `invalid` are separated for the caller's benefit only — one of them is worth a log
+ * line and the other is not. Both reach the person as the same words, because a distinct "too many
+ * attempts" message tells an attacker their guessing is registering against a real account.
+ */
+export async function verifyForAccount(
+	bucketId: string,
+	accountId: string,
+	code: string
+): Promise<Outcome> {
+	const store = getUserStore(bucketId);
+	const user = await store.find(accountId);
+	if (!user?.totp) {
+		return { ok: false, reason: 'not_enrolled' };
+	}
+
+	const now = epochTime();
+	const key = attemptKey(bucketId, accountId);
+	const prior = (await attempts().find(key)) as TotpAttemptPayload | undefined;
+	const windowActive =
+		prior !== undefined && now - prior.windowStart < ACCOUNT_WINDOW_SECONDS;
+
+	// Checked before verifying, so a locked-out account refuses even a correct code — the same shape
+	// lib/verification/challenge.ts uses once its attempt cap is reached.
+	if (windowActive && prior.failures >= ACCOUNT_FAILURE_CAP) {
+		return { ok: false, reason: 'throttled' };
+	}
+
+	const step = verifyAt(decodeBase32(user.totp.secret), code, now, {
+		after: user.totp.lastStep
+	});
+
+	if (step === null) {
+		const failures = windowActive ? prior.failures + 1 : 1;
+		const windowStart = windowActive ? prior.windowStart : now;
+		// The record dies with the window rather than outliving it, so a lockout cannot become permanent.
+		const ttl = Math.max(1, windowStart + ACCOUNT_WINDOW_SECONDS - now);
+		await attempts().upsert(
+			key,
+			{ accountId, failures, windowStart, exp: now + ttl },
+			ttl
+		);
+		return { ok: false, reason: 'invalid' };
+	}
+
+	/*
+	 * Advancing `lastStep` is what makes FR-018 true, and it is the easiest part of this to lose: with
+	 * verification implemented as a pure predicate, a code observed in flight stays usable for the whole
+	 * remaining drift band.
+	 */
+	await store.update(accountId, { totp: { ...user.totp, lastStep: step } });
+	await attempts().destroy(key);
+	return { ok: true };
+}
+
+/* A clean slate: on a completed sign-in, and when an operator clears the enrolment entirely. */
+export async function clearAttempts(
+	bucketId: string,
+	accountId: string
+): Promise<void> {
+	await attempts().destroy(attemptKey(bucketId, accountId));
+}

--- a/lib/totp/verify.ts
+++ b/lib/totp/verify.ts
@@ -81,8 +81,23 @@ export async function verifyForAccount(
 	 * Advancing `lastStep` is what makes FR-018 true, and it is the easiest part of this to lose: with
 	 * verification implemented as a pure predicate, a code observed in flight stays usable for the whole
 	 * remaining drift band.
+	 *
+	 * Which is also why the write is checked rather than fired and forgotten. `update` returns null only
+	 * when the row has gone — deleted between the read above and here — and reporting success on that
+	 * would do two wrong things at once: sign a person in as an account that no longer exists, and
+	 * report a verification whose replay guard never moved.
+	 *
+	 * `not_enrolled` rather than a reason of its own, because it is true and because the caller already
+	 * routes it somewhere terminating: the enrolment GET looks the account up, does not find it either,
+	 * and sends them back to the login door.
 	 */
-	await store.update(accountId, { totp: { ...user.totp, lastStep: step } });
+	const advanced = await store.update(accountId, {
+		totp: { ...user.totp, lastStep: step }
+	});
+	if (!advanced) {
+		return { ok: false, reason: 'not_enrolled' };
+	}
+
 	await attempts().destroy(key);
 	return { ok: true };
 }

--- a/test/admin/audit_route_classification.spec.ts
+++ b/test/admin/audit_route_classification.spec.ts
@@ -60,11 +60,12 @@ describe('admin audit route classification', () => {
 
 		/*
 		 * Counted exactly, and the numbers grow with the table: 23 + the four federation rows (three provider
-		 * operations and one identity severance) + the error-store purge. A count that drifted upward
-		 * silently would let an audited route be swapped for an unaudited one without either total changing.
+		 * operations and one identity severance) + the error-store purge + clearing an end-user's
+		 * authenticator. A count that drifted upward silently would let an audited route be swapped for an
+		 * unaudited one without either total changing.
 		 */
-		expect(auditedAdminRoutes).toHaveLength(28);
-		expect(mounted).toHaveLength(29);
+		expect(auditedAdminRoutes).toHaveLength(29);
+		expect(mounted).toHaveLength(30);
 	});
 
 	it('declares each route pattern only once', () => {

--- a/test/mcp/capability_invariance.spec.ts
+++ b/test/mcp/capability_invariance.spec.ts
@@ -159,7 +159,7 @@ describe('published operation set is capability-invariant', () => {
 		}
 
 		const [first, ...rest] = [...seen.values()];
-		expect(first.length).toBe(44);
+		expect(first.length).toBe(45);
 		for (const [label, names] of [...seen.entries()].slice(1)) {
 			expect(names, `tool list changed under: ${label}`).toEqual(first);
 		}

--- a/test/mcp/catalogue_drift.spec.ts
+++ b/test/mcp/catalogue_drift.spec.ts
@@ -29,10 +29,10 @@ const mountedApi = mounted.routes
 	.map((r) => ({ method: r.method, path: r.path }));
 
 describe('MCP tool catalogue', () => {
-	it('publishes 44 tools: 20 reads and 24 writes', () => {
-		expect(mcpCatalogue.length).toBe(44);
+	it('publishes 45 tools: 20 reads and 25 writes', () => {
+		expect(mcpCatalogue.length).toBe(45);
 		expect(mcpCatalogue.filter((t) => t.method === 'GET').length).toBe(20);
-		expect(mcpCatalogue.filter((t) => t.method !== 'GET').length).toBe(24);
+		expect(mcpCatalogue.filter((t) => t.method !== 'GET').length).toBe(25);
 	});
 
 	it('names exactly four exclusions', () => {

--- a/test/mcp/confirmation_matrix.spec.ts
+++ b/test/mcp/confirmation_matrix.spec.ts
@@ -215,7 +215,7 @@ describe('every high-consequence tool is gated', () => {
 		const gated = mcpCatalogue.filter(
 			(t) => t.consequence === 'ordinary' || t.consequence === 'read'
 		);
-		expect(gated.length).toBe(44 - 11);
+		expect(gated.length).toBe(45 - 11);
 		for (const tool of gated) {
 			expect(tool.consequence, tool.tool).not.toBe('high');
 		}

--- a/test/mcp/dispatch_contract.spec.ts
+++ b/test/mcp/dispatch_contract.spec.ts
@@ -221,7 +221,7 @@ describe('in-process re-dispatch into the admin routes', () => {
 	// Q6. The route inventory the drift guard (T006) will compare against.
 	it('exposes the mounted route set for the drift guard', () => {
 		const api = composed.routes.filter((r) => r.path.startsWith('/admin/api'));
-		expect(api.length).toBe(40);
+		expect(api.length).toBe(41);
 
 		// The three /admin/api routes NOT in any route plugin. Two are excluded from MCP anyway;
 		// `GET /admin/api/me` is not, and the whoami tool needs it — so it must be extracted from

--- a/test/storage_contract/inventory_expiry.spec.ts
+++ b/test/storage_contract/inventory_expiry.spec.ts
@@ -37,6 +37,14 @@ const REAPED_ON_EXPIRES_AT = [
 	'RegistrationAccessToken',
 	'ReplayDetection',
 	'Session',
+	/*
+	 * The second factor's two areas, and expiry is the control in both rather than housekeeping. An
+	 * enrolment offer that outlived its window would leave a secret nobody proved sitting against a
+	 * live account; a failure window that never expired would lock an account out for good on ten
+	 * mistyped digits.
+	 */
+	'TotpAttempt',
+	'TotpEnrollment',
 	'VerificationChallenge',
 	'VerificationResend',
 	'adminSession',

--- a/test/storage_contract/payload_schemas.ts
+++ b/test/storage_contract/payload_schemas.ts
@@ -36,6 +36,7 @@ import {
 	VerificationChallengePayload,
 	VerificationResendPayload
 } from 'lib/verification/types.js';
+import { TotpAttemptPayload, TotpEnrollmentPayload } from 'lib/totp/types.js';
 
 export interface ReadableSchema {
 	readonly properties: Record<string, unknown>;
@@ -58,6 +59,8 @@ export const PAYLOAD_SCHEMAS: Readonly<Record<string, ReadableSchema>> = {
 	RegistrationAccessToken: RegistrationAccessTokenPayload,
 	ReplayDetection: ReplayDetectionPayload,
 	Session: SessionPayload,
+	TotpAttempt: TotpAttemptPayload,
+	TotpEnrollment: TotpEnrollmentPayload,
 	VerificationChallenge: VerificationChallengePayload,
 	VerificationResend: VerificationResendPayload
 };

--- a/test/totp/admin_clear.spec.ts
+++ b/test/totp/admin_clear.spec.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { treaty } from '@elysiajs/eden';
+import { resolveAdmin } from 'lib/admin/auth/rbac.ts';
+import { endUserRoutes } from 'lib/admin/users-end/routes.ts';
+import { ensureAdminSeed } from 'lib/admin/seed.ts';
+import {
+	adapter,
+	adminAuditStore,
+	adminSessionStore,
+	getBucketStore,
+	getUserStore
+} from 'lib/adapters/index.ts';
+import { ADMIN_BUCKET_ID, ADMIN_SESSION_COOKIE } from 'lib/admin/consts.ts';
+import { encodeBase32 } from 'lib/totp/base32.ts';
+import { attemptKey } from 'lib/totp/verify.ts';
+import epochTime from 'lib/helpers/epoch_time.ts';
+import type { User } from 'lib/adapters/types.ts';
+
+const app = new Elysia().use(resolveAdmin).use(endUserRoutes);
+const client = treaty(app);
+
+const SECRET = encodeBase32(Buffer.from('12345678901234567890', 'ascii'));
+
+let seq = 0;
+const unique = (prefix: string) => `${prefix}-${Date.now()}-${(seq += 1)}`;
+
+async function sessionCookieFor(roles: string[]) {
+	const user = await getUserStore(ADMIN_BUCKET_ID).create(
+		`${unique(roles.join('-'))}@x.io`,
+		'hash',
+		roles
+	);
+	const session = await adminSessionStore.create({
+		userId: user._id,
+		bucketId: ADMIN_BUCKET_ID,
+		tokens: {},
+		ttlSeconds: 60,
+		absoluteTtlSeconds: 3600
+	});
+	return { cookie: `${ADMIN_SESSION_COOKIE}=${session._id}`, userId: user._id };
+}
+
+async function enrolledAccount(bucketId: string) {
+	const user = await getUserStore(bucketId).create(
+		`${unique('member')}@x.io`,
+		'hash',
+		[]
+	);
+	await getUserStore(bucketId).update(user._id, {
+		totp: { secret: SECRET, enrolledAt: new Date(), lastStep: 42 }
+	});
+	return user;
+}
+
+describe('clearing a lost authenticator (US5)', () => {
+	let bucketId: string;
+	let admin: { cookie: string; userId: string };
+
+	beforeEach(async () => {
+		await ensureAdminSeed();
+		admin = await sessionCookieFor(['super_admin']);
+		const bucket = await getBucketStore().create({
+			name: unique('Recovery'),
+			managedBy: [admin.userId],
+			totpRequired: true
+		});
+		bucketId = bucket._id;
+	});
+
+	it('reports whether an account is enrolled, and when', async () => {
+		const user = await enrolledAccount(bucketId);
+		const res = await client.admin.api
+			.buckets({ id: bucketId })
+			.users.get({ headers: { cookie: admin.cookie } });
+
+		expect(res.status).toBe(200);
+		const listed = (res.data as { _id: string }[]).find(
+			(u) => u._id === user._id
+		) as { totpEnrolled?: boolean; totpEnrolledAt?: string } | undefined;
+		expect(listed?.totpEnrolled).toBe(true);
+		expect(listed?.totpEnrolledAt).toBeTruthy();
+	});
+
+	it('reports an unenrolled account as such', async () => {
+		const user = await getUserStore(bucketId).create(
+			`${unique('plain')}@x.io`,
+			'hash',
+			[]
+		);
+		const res = await client.admin.api
+			.buckets({ id: bucketId })
+			.users.get({ headers: { cookie: admin.cookie } });
+		const listed = (res.data as { _id: string }[]).find(
+			(u) => u._id === user._id
+		) as { totpEnrolled?: boolean; totpEnrolledAt?: string | null } | undefined;
+		expect(listed?.totpEnrolled).toBe(false);
+		expect(listed?.totpEnrolledAt).toBeNull();
+	});
+
+	/*
+	 * The property the whole design rests on. TOTP verification is symmetric, so the server must hold a
+	 * recoverable secret — which makes "it never leaves through a read" the only protection there is.
+	 */
+	it('never emits the secret through any end-user read', async () => {
+		await enrolledAccount(bucketId);
+
+		const list = await client.admin.api
+			.buckets({ id: bucketId })
+			.users.get({ headers: { cookie: admin.cookie } });
+		expect(JSON.stringify(list.data)).not.toContain(SECRET);
+		expect(JSON.stringify(list.data)).not.toContain('"totp"');
+
+		const created = await client.admin.api
+			.buckets({ id: bucketId })
+			.users.post(
+				{ email: `${unique('fresh')}@x.io`, password: 'hunter22hunter' },
+				{ headers: { cookie: admin.cookie } }
+			);
+		expect(JSON.stringify(created.data)).not.toContain('"totp"');
+		expect(JSON.stringify(created.data)).not.toContain('"password"');
+	});
+
+	it('clears the enrolment, immediately', async () => {
+		const user = await enrolledAccount(bucketId);
+
+		const res = await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: user._id })
+			.totp.delete(undefined, { headers: { cookie: admin.cookie } });
+
+		expect(res.status).toBe(200);
+		const after = await getUserStore(bucketId).find(user._id);
+		expect(after?.totp).toBeUndefined();
+	});
+
+	it('ends the account sessions, so none outlives the factor that made it', async () => {
+		const user = await enrolledAccount(bucketId);
+		await adapter('Session').upsert(
+			'session-to-die',
+			{ accountId: user._id, uid: 'u1', exp: epochTime() + 600 },
+			600
+		);
+
+		await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: user._id })
+			.totp.delete(undefined, { headers: { cookie: admin.cookie } });
+
+		expect(await adapter('Session').find('session-to-die')).toBeUndefined();
+	});
+
+	it('clears any standing lockout, so a fresh enrolment is not born throttled', async () => {
+		const user = await enrolledAccount(bucketId);
+		const key = attemptKey(bucketId, user._id);
+		await adapter('TotpAttempt').upsert(
+			key,
+			{
+				accountId: user._id,
+				failures: 99,
+				windowStart: epochTime(),
+				exp: epochTime() + 600
+			},
+			600
+		);
+
+		await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: user._id })
+			.totp.delete(undefined, { headers: { cookie: admin.cookie } });
+
+		expect(await adapter('TotpAttempt').find(key)).toBeUndefined();
+	});
+
+	it('succeeds on an account that holds no authenticator', async () => {
+		const user = await getUserStore(bucketId).create(
+			`${unique('none')}@x.io`,
+			'hash',
+			[]
+		);
+		const res = await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: user._id })
+			.totp.delete(undefined, { headers: { cookie: admin.cookie } });
+		// An operator should not have to know the current state to reach the intended one.
+		expect(res.status).toBe(200);
+	});
+
+	it('answers 404 for an account that does not exist', async () => {
+		const res = await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: 'no-such-account' })
+			.totp.delete(undefined, { headers: { cookie: admin.cookie } });
+		expect(res.status).toBe(404);
+	});
+
+	it('refuses a caller with no rights over the bucket, changing nothing', async () => {
+		const user = await enrolledAccount(bucketId);
+		const outsider = await sessionCookieFor(['project_admin']);
+
+		const res = await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: user._id })
+			.totp.delete(undefined, { headers: { cookie: outsider.cookie } });
+
+		expect(res.status).toBe(403);
+		const after = await getUserStore(bucketId).find(user._id);
+		expect(after?.totp?.secret).toBe(SECRET);
+	});
+
+	it('refuses an unauthenticated caller, changing nothing', async () => {
+		const user = await enrolledAccount(bucketId);
+
+		const res = await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: user._id })
+			.totp.delete();
+
+		expect(res.status).toBe(401);
+		const after = await getUserStore(bucketId).find(user._id);
+		expect(after?.totp?.secret).toBe(SECRET);
+	});
+
+	it('records the act against the actor, naming no value', async () => {
+		const user = await enrolledAccount(bucketId);
+
+		await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: user._id })
+			.totp.delete(undefined, { headers: { cookie: admin.cookie } });
+
+		const { entries } = await adminAuditStore.list({
+			targetType: 'EndUser',
+			targetId: user._id
+		});
+		const entry = entries.find((e) => e.action === 'enduser.totp.clear');
+		expect(entry).toBeDefined();
+		expect(entry?.actorId).toBe(admin.userId);
+		expect(entry?.targetScope).toBe(bucketId);
+		expect(entry?.timestamp).toBeDefined();
+		expect(JSON.stringify(entry)).not.toContain(SECRET);
+	});
+
+	// Clearing is a reset, not a deletion: consent survives it. Conflating the two is how a password
+	// change would start destroying grants.
+	it('leaves the account itself and its grants alone', async () => {
+		const user = await enrolledAccount(bucketId);
+		await adapter('Grant').upsert(
+			'grant-that-stays',
+			{
+				accountId: user._id,
+				clientId: 'c',
+				trusted: false,
+				createdAt: epochTime(),
+				lastModifiedAt: epochTime(),
+				exp: epochTime() + 600
+			},
+			600
+		);
+
+		await client.admin.api
+			.buckets({ id: bucketId })
+			.users({ uid: user._id })
+			.totp.delete(undefined, { headers: { cookie: admin.cookie } });
+
+		expect(await adapter('Grant').find('grant-that-stays')).toBeDefined();
+		const after = (await getUserStore(bucketId).find(user._id)) as User;
+		expect(after.email).toBeTruthy();
+		expect(after.active).toBe(true);
+	});
+});

--- a/test/totp/algorithm.spec.ts
+++ b/test/totp/algorithm.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'bun:test';
+import { encodeBase32, decodeBase32 } from 'lib/totp/base32.ts';
+import { hotp, stepFor, verifyAt } from 'lib/totp/code.ts';
+import { STEP_SECONDS } from 'lib/totp/consts.ts';
+
+// The secret every published vector uses: the ASCII digits 1-0 repeated to 20 bytes.
+const SEED = Buffer.from('12345678901234567890', 'ascii');
+
+describe('base32 (RFC 4648 §6)', () => {
+	// RFC 4648 §10 test vectors, unpadded — the padding this codec omits is the '=' run at the end.
+	const vectors: [string, string][] = [
+		['', ''],
+		['f', 'MY'],
+		['fo', 'MZXQ'],
+		['foo', 'MZXW6'],
+		['foob', 'MZXW6YQ'],
+		['fooba', 'MZXW6YTB'],
+		['foobar', 'MZXW6YTBOI']
+	];
+
+	for (const [plain, encoded] of vectors) {
+		it(`encodes ${JSON.stringify(plain)} as ${JSON.stringify(encoded)}`, () => {
+			expect(encodeBase32(Buffer.from(plain, 'ascii'))).toBe(encoded);
+		});
+
+		it(`decodes ${JSON.stringify(encoded)} back to ${JSON.stringify(plain)}`, () => {
+			expect(decodeBase32(encoded).toString('ascii')).toBe(plain);
+		});
+	}
+
+	it('round-trips the 20-byte seed', () => {
+		expect(decodeBase32(encodeBase32(SEED)).equals(SEED)).toBe(true);
+	});
+
+	// A person retyping a secret off a screen produces both of these.
+	it('tolerates lowercase and embedded spaces on decode', () => {
+		const encoded = encodeBase32(SEED);
+		const grouped = (encoded.match(/.{1,4}/g) ?? []).join(' ').toLowerCase();
+		expect(decodeBase32(grouped).equals(SEED)).toBe(true);
+	});
+
+	it('refuses a character outside the alphabet', () => {
+		expect(() => decodeBase32('MZXW6YTB!')).toThrow();
+	});
+});
+
+describe('hotp (RFC 4226 Appendix D)', () => {
+	const expected = [
+		'755224',
+		'287082',
+		'359152',
+		'969429',
+		'338314',
+		'254676',
+		'287922',
+		'162583',
+		'399871',
+		'520489'
+	];
+
+	expected.forEach((code, counter) => {
+		it(`counter ${counter} yields ${code}`, () => {
+			expect(hotp(SEED, counter)).toBe(code);
+		});
+	});
+});
+
+describe('totp (RFC 6238 Appendix B)', () => {
+	// The SHA-1 column. Eight digits, which is what the appendix tabulates.
+	const vectors: [number, string][] = [
+		[59, '94287082'],
+		[1111111109, '07081804'],
+		[1111111111, '14050471'],
+		[1234567890, '89005924'],
+		[2000000000, '69279037'],
+		[20000000000, '65353130']
+	];
+
+	for (const [time, code] of vectors) {
+		it(`T=${time} yields ${code}`, () => {
+			expect(hotp(SEED, stepFor(time), 8)).toBe(code);
+		});
+	}
+
+	it('derives the step by flooring the unix time over the period', () => {
+		expect(stepFor(0)).toBe(0);
+		expect(stepFor(STEP_SECONDS - 1)).toBe(0);
+		expect(stepFor(STEP_SECONDS)).toBe(1);
+		expect(stepFor(59)).toBe(1);
+	});
+});
+
+describe('verifyAt', () => {
+	const NOW = 1234567890;
+	const step = stepFor(NOW);
+
+	it('accepts the current step and returns it', () => {
+		expect(verifyAt(SEED, hotp(SEED, step), NOW)).toBe(step);
+	});
+
+	it('accepts the step before and the step after', () => {
+		expect(verifyAt(SEED, hotp(SEED, step - 1), NOW)).toBe(step - 1);
+		expect(verifyAt(SEED, hotp(SEED, step + 1), NOW)).toBe(step + 1);
+	});
+
+	it('refuses two steps out in either direction', () => {
+		expect(verifyAt(SEED, hotp(SEED, step - 2), NOW)).toBeNull();
+		expect(verifyAt(SEED, hotp(SEED, step + 2), NOW)).toBeNull();
+	});
+
+	it('refuses a code that is not a code at all', () => {
+		expect(verifyAt(SEED, '000000', NOW)).toBeNull();
+		expect(verifyAt(SEED, '', NOW)).toBeNull();
+		expect(verifyAt(SEED, 'abcdef', NOW)).toBeNull();
+	});
+
+	// The replay guard: a step at or below `after` is spent, even though it is still within the band.
+	it('refuses a step at or below `after`', () => {
+		expect(verifyAt(SEED, hotp(SEED, step), NOW, { after: step })).toBeNull();
+		expect(
+			verifyAt(SEED, hotp(SEED, step - 1), NOW, { after: step })
+		).toBeNull();
+	});
+
+	it('still accepts the next step once `after` is set', () => {
+		expect(verifyAt(SEED, hotp(SEED, step + 1), NOW, { after: step })).toBe(
+			step + 1
+		);
+	});
+});

--- a/test/totp/bucket_setting.spec.ts
+++ b/test/totp/bucket_setting.spec.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { treaty } from '@elysiajs/eden';
+import { resolveAdmin } from 'lib/admin/auth/rbac.ts';
+import { bucketRoutes } from 'lib/admin/buckets/routes.ts';
+import { ensureAdminSeed } from 'lib/admin/seed.ts';
+import {
+	adminSessionStore,
+	adminAuditStore,
+	getBucketStore,
+	getProjectStore,
+	getUserStore
+} from 'lib/adapters/index.ts';
+import { ADMIN_BUCKET_ID, ADMIN_SESSION_COOKIE } from 'lib/admin/consts.ts';
+import type { UserBucket } from 'lib/adapters/types.ts';
+
+const app = new Elysia().use(resolveAdmin).use(bucketRoutes);
+const client = treaty(app);
+
+let seq = 0;
+const unique = (prefix: string) => `${prefix}-${Date.now()}-${(seq += 1)}`;
+
+async function sessionCookieFor(roles: string[]) {
+	const user = await getUserStore(ADMIN_BUCKET_ID).create(
+		`${unique(roles.join('-'))}@x.io`,
+		'hash',
+		roles
+	);
+	const session = await adminSessionStore.create({
+		userId: user._id,
+		bucketId: ADMIN_BUCKET_ID,
+		tokens: {},
+		ttlSeconds: 60,
+		absoluteTtlSeconds: 3600
+	});
+	return { cookie: `${ADMIN_SESSION_COOKIE}=${session._id}`, userId: user._id };
+}
+
+async function superCookie() {
+	return (await sessionCookieFor(['super_admin'])).cookie;
+}
+
+describe('bucket sign-in method setting', () => {
+	beforeEach(async () => {
+		await ensureAdminSeed();
+	});
+
+	it('defaults a newly created bucket to not requiring the second factor', async () => {
+		const cookie = await superCookie();
+		const res = await client.admin.api.buckets.post(
+			{ name: unique('Defaults') },
+			{ headers: { cookie } }
+		);
+		expect((res.data as UserBucket).totpRequired).toBe(false);
+	});
+
+	// A bucket document written before this field existed holds no value for it. Reading it back as
+	// undefined would be falsy and therefore accidentally correct — but only accidentally, and the
+	// same shape closed the password door on every existing bucket once before. The read must default.
+	it('reads a bucket that predates the field as not requiring it', async () => {
+		const cookie = await superCookie();
+		const bucket = await getBucketStore().create({ name: unique('Legacy') });
+
+		// The in-memory store hands back the live record, so this is the stored document losing a field.
+		delete (bucket as Partial<UserBucket>).totpRequired;
+
+		const res = await client.admin.api
+			.buckets({ id: bucket._id })
+			.get({ headers: { cookie } });
+		expect(res.status).toBe(200);
+		expect((res.data as UserBucket).totpRequired).toBe(false);
+	});
+
+	it('accepts the setting at creation', async () => {
+		const cookie = await superCookie();
+		const res = await client.admin.api.buckets.post(
+			{ name: unique('Strict'), totpRequired: true },
+			{ headers: { cookie } }
+		);
+		expect((res.data as UserBucket).totpRequired).toBe(true);
+	});
+
+	it('persists a change and leaves every other bucket alone', async () => {
+		const cookie = await superCookie();
+		const first = (
+			await client.admin.api.buckets.post(
+				{ name: unique('First') },
+				{ headers: { cookie } }
+			)
+		).data as UserBucket;
+		const second = (
+			await client.admin.api.buckets.post(
+				{ name: unique('Second') },
+				{ headers: { cookie } }
+			)
+		).data as UserBucket;
+
+		const patched = await client.admin.api
+			.buckets({ id: first._id })
+			.patch({ totpRequired: true }, { headers: { cookie } });
+		expect(patched.status).toBe(200);
+		expect((patched.data as UserBucket).totpRequired).toBe(true);
+
+		const untouched = await client.admin.api
+			.buckets({ id: second._id })
+			.get({ headers: { cookie } });
+		expect((untouched.data as UserBucket).totpRequired).toBe(false);
+
+		// And it survives a read, rather than only appearing in the patch response.
+		expect((await getBucketStore().find(first._id))?.totpRequired).toBe(true);
+	});
+
+	it('turns the requirement back off', async () => {
+		const cookie = await superCookie();
+		const bucket = (
+			await client.admin.api.buckets.post(
+				{ name: unique('Toggling'), totpRequired: true },
+				{ headers: { cookie } }
+			)
+		).data as UserBucket;
+
+		const patched = await client.admin.api
+			.buckets({ id: bucket._id })
+			.patch({ totpRequired: false }, { headers: { cookie } });
+		expect((patched.data as UserBucket).totpRequired).toBe(false);
+	});
+
+	/*
+	 * Permitted but inert, and the operator is told so. Refusing would be wrong: recording the intended
+	 * posture before opening the password door is a reasonable order to do things in.
+	 */
+	it('advises, rather than refuses, when password sign-in is off', async () => {
+		const cookie = await superCookie();
+		const bucket = (
+			await client.admin.api.buckets.post(
+				{ name: unique('Federated') },
+				{ headers: { cookie } }
+			)
+		).data as UserBucket;
+
+		// A provider has to exist before password login can be switched off, or the lockout guard refuses.
+		await getBucketStore().update(bucket._id, {
+			passwordLogin: false,
+			federation: [
+				{
+					id: 'acme',
+					displayName: 'Acme',
+					issuer: 'https://idp.example.com',
+					clientId: 'x',
+					clientSecret: 'y',
+					scopes: ['openid'],
+					enabled: true,
+					provisioning: 'jit',
+					emailTrusted: true,
+					allowedEmailDomains: [],
+					emailClaim: 'email'
+				}
+			]
+		});
+
+		const patched = await client.admin.api
+			.buckets({ id: bucket._id })
+			.patch({ totpRequired: true }, { headers: { cookie } });
+
+		expect(patched.status).toBe(200);
+		expect((patched.data as UserBucket).totpRequired).toBe(true);
+		expect((patched.data as { advisory?: string }).advisory).toContain(
+			'passwordLogin'
+		);
+	});
+
+	it('carries no advisory when password sign-in is on', async () => {
+		const cookie = await superCookie();
+		const bucket = (
+			await client.admin.api.buckets.post(
+				{ name: unique('Normal') },
+				{ headers: { cookie } }
+			)
+		).data as UserBucket;
+
+		const patched = await client.admin.api
+			.buckets({ id: bucket._id })
+			.patch({ totpRequired: true }, { headers: { cookie } });
+		expect((patched.data as { advisory?: string }).advisory).toBeUndefined();
+	});
+
+	it('refuses a caller with no rights over the bucket, changing nothing', async () => {
+		const cookie = await superCookie();
+		const outsider = await sessionCookieFor(['project_admin']);
+		const bucket = (
+			await client.admin.api.buckets.post(
+				{ name: unique('NotYours') },
+				{ headers: { cookie } }
+			)
+		).data as UserBucket;
+
+		const res = await client.admin.api
+			.buckets({ id: bucket._id })
+			.patch({ totpRequired: true }, { headers: { cookie: outsider.cookie } });
+
+		expect(res.status).toBe(403);
+		expect((await getBucketStore().find(bucket._id))?.totpRequired).toBe(false);
+	});
+
+	it('refuses an unauthenticated caller', async () => {
+		const cookie = await superCookie();
+		const bucket = (
+			await client.admin.api.buckets.post(
+				{ name: unique('Anon') },
+				{ headers: { cookie } }
+			)
+		).data as UserBucket;
+
+		const res = await client.admin.api
+			.buckets({ id: bucket._id })
+			.patch({ totpRequired: true });
+
+		expect(res.status).toBe(401);
+		expect((await getBucketStore().find(bucket._id))?.totpRequired).toBe(false);
+	});
+
+	/*
+	 * The trail records the actor and which field was exercised, and deliberately not the values —
+	 * entries carry field *names* only, which is what makes "no secret can reach the trail" a
+	 * structural property rather than a redaction rule every future call site has to remember
+	 * (test/admin/audit_secrecy.spec.ts). The value is recoverable anyway: the bucket holds the
+	 * current one and the ordered entries naming this field give every flip since the `false` default.
+	 */
+	it('records the change against the actor, naming the field and not its value', async () => {
+		const admin = await sessionCookieFor(['super_admin']);
+		const bucket = (
+			await client.admin.api.buckets.post(
+				{ name: unique('Audited') },
+				{ headers: { cookie: admin.cookie } }
+			)
+		).data as UserBucket;
+
+		await client.admin.api
+			.buckets({ id: bucket._id })
+			.patch({ totpRequired: true }, { headers: { cookie: admin.cookie } });
+
+		const { entries } = await adminAuditStore.list({
+			targetType: 'UserBucket',
+			targetId: bucket._id
+		});
+		const update = entries.find((entry) => entry.action === 'bucket.update');
+		expect(update).toBeDefined();
+		expect(update?.actorId).toBe(admin.userId);
+		// Flattened onto the entry, not nested under a `detail` object — the store's shape.
+		expect(update?.attributes).toContain('totpRequired');
+		expect(update?.timestamp).toBeDefined();
+		// No from/to pair anywhere in the entry.
+		expect(JSON.stringify(update)).not.toContain('"to"');
+		expect(JSON.stringify(update)).not.toContain('"from"');
+	});
+
+	// The requirement narrows a door; it does not remove one. The lockout guard is about a bucket with
+	// no way in at all, and must not start refusing a bucket that simply asks for more proof.
+	it('does not engage the no-way-to-sign-in guard', async () => {
+		const cookie = await superCookie();
+		const bucket = (
+			await client.admin.api.buckets.post(
+				{ name: unique('StillReachable'), totpRequired: true },
+				{ headers: { cookie } }
+			)
+		).data as UserBucket;
+		expect(bucket.totpRequired).toBe(true);
+		expect(bucket.passwordLogin).toBe(true);
+	});
+
+	it('keeps the setting out of a project-scoped manager they do not manage', async () => {
+		const cookie = await superCookie();
+		const manager = await sessionCookieFor(['project_admin']);
+		const bucket = await getBucketStore().create({
+			name: unique('Managed'),
+			managedBy: [manager.userId]
+		});
+		const project = await getProjectStore().create({
+			name: unique('Proj'),
+			slug: unique('proj'),
+			managedBy: [manager.userId]
+		});
+		await getProjectStore().update(project._id, { bucketId: bucket._id });
+
+		// A project admin may read the bucket their project points at, and must see the setting.
+		const read = await client.admin.api
+			.buckets({ id: bucket._id })
+			.get({ headers: { cookie: manager.cookie } });
+		expect(read.status).toBe(200);
+		expect((read.data as UserBucket).totpRequired).toBe(false);
+		expect(cookie).toBeTruthy();
+	});
+});

--- a/test/totp/migration.spec.ts
+++ b/test/totp/migration.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeAll } from 'bun:test';
+import bootstrap, { agent, getHeader } from '../test_helper.ts';
+import { AuthorizationRequest } from '../AuthorizationRequest.ts';
+import {
+	getBucketStore,
+	getProjectStore,
+	getUserStore,
+	resetAdminMemoryStores
+} from 'lib/adapters/index.ts';
+import { elysia } from 'lib/index.ts';
+import { decodeBase32 } from 'lib/totp/base32.ts';
+import { hotp, stepFor } from 'lib/totp/code.ts';
+import epochTime from 'lib/helpers/epoch_time.ts';
+
+const PASSWORD = 'correct horse battery';
+
+let bucketId: string;
+
+async function startInteraction(clientId: string) {
+	const auth = new AuthorizationRequest({
+		client_id: clientId,
+		scope: 'openid'
+	});
+	const { response } = await agent.auth.get({ query: auth.params });
+	const location = getHeader(response, 'location');
+	const uid = location.split('/')[2];
+	const cookie = response.headers.get('set-cookie');
+	if (!cookie) throw new Error('expected an interaction cookie from /auth');
+	return { uid, cookie };
+}
+
+async function postForm(
+	path: string,
+	cookie: string,
+	fields: Record<string, string>
+) {
+	const res = await elysia.handle(
+		new Request(`http://e.ly${path}`, {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				cookie
+			},
+			body: new URLSearchParams(fields).toString(),
+			redirect: 'manual'
+		})
+	);
+	return {
+		status: res.status,
+		text: await res.text(),
+		location: res.headers.get('location'),
+		setCookie: res.headers.get('set-cookie')
+	};
+}
+
+async function getPage(path: string, cookie: string) {
+	const res = await elysia.handle(
+		new Request(`http://e.ly${path}`, { headers: { cookie } })
+	);
+	return {
+		status: res.status,
+		text: await res.text(),
+		location: res.headers.get('location')
+	};
+}
+
+function secretFrom(html: string): string {
+	const props = /window\.PROPS=(\{.*?\})<\/script>/s.exec(html)?.[1];
+	if (!props) throw new Error('the enrolment page carried no props script');
+	const parsed = JSON.parse(props) as { secretText?: string };
+	if (!parsed.secretText) throw new Error('the props carried no secret');
+	return parsed.secretText.replace(/\s+/g, '');
+}
+
+function codeFor(secret: string): string {
+	return hotp(decodeBase32(secret), stepFor(epochTime()));
+}
+
+async function signIn(email: string) {
+	const { uid, cookie } = await startInteraction('totp-migrate-app');
+	const res = await postForm(`/ui/${uid}/login`, cookie, {
+		username: email,
+		password: PASSWORD
+	});
+	return { uid, cookie, res };
+}
+
+async function raise(required: boolean) {
+	await getBucketStore().update(bucketId, { totpRequired: required });
+}
+
+describe('bringing existing accounts under the requirement (US4)', () => {
+	beforeAll(async () => {
+		await bootstrap(import.meta.url, { config: 'totp' });
+		resetAdminMemoryStores();
+		const bucket = await getBucketStore().create({
+			name: 'Migrating',
+			totpRequired: false
+		});
+		bucketId = bucket._id;
+		const project = await getProjectStore().create({
+			name: 'Migrating',
+			slug: `migrate-${Math.random()}`
+		});
+		await getProjectStore().update(project._id, {
+			bucketId,
+			clientIds: ['totp-migrate-app']
+		});
+	});
+
+	async function existingAccount(label: string) {
+		const email = `${label}-${Math.random()}@x.io`;
+		await getUserStore(bucketId).create(
+			email,
+			await Bun.password.hash(PASSWORD),
+			[],
+			true
+		);
+		return email;
+	}
+
+	it('signs an existing account in with the password alone while the bucket is open', async () => {
+		await raise(false);
+		const email = await existingAccount('before');
+		const { res } = await signIn(email);
+		expect(res.status).toBe(303);
+		expect(res.setCookie ?? '').toContain('_session=');
+	});
+
+	it('routes an unenrolled account to enrolment once the bucket is raised', async () => {
+		const email = await existingAccount('raised');
+		await raise(true);
+
+		const { uid, res } = await signIn(email);
+		expect(res.status).toBe(303);
+		expect(res.location).toBe(`/ui/${uid}/totp/enroll`);
+		// Not signed in on the way past.
+		expect(res.setCookie ?? '').not.toContain('_session=');
+	});
+
+	it('completes that sign-in inline, without a second visit', async () => {
+		const email = await existingAccount('inline');
+		await raise(true);
+
+		const { uid, cookie } = await signIn(email);
+		const page = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		const res = await postForm(`/ui/${uid}/totp/enroll`, cookie, {
+			code: codeFor(secretFrom(page.text))
+		});
+
+		expect(res.status).toBe(303);
+		expect(res.setCookie ?? '').toContain('_session=');
+		expect(res.location ?? '').toMatch(/\/consent$|\/callback/);
+	});
+
+	it('asks only for the code at the next sign-in, not for enrolment again', async () => {
+		const email = await existingAccount('second-visit');
+		await raise(true);
+
+		const first = await signIn(email);
+		const page = await getPage(`/ui/${first.uid}/totp/enroll`, first.cookie);
+		const secret = secretFrom(page.text);
+		await postForm(`/ui/${first.uid}/totp/enroll`, first.cookie, {
+			code: codeFor(secret)
+		});
+
+		const second = await signIn(email);
+		expect(second.res.location).toBe(`/ui/${second.uid}/totp`);
+	});
+
+	it('leaves someone who abandons enrolment signed out', async () => {
+		const email = await existingAccount('abandoning');
+		await raise(true);
+
+		const { uid, cookie } = await signIn(email);
+		await getPage(`/ui/${uid}/totp/enroll`, cookie);
+
+		// They walk away. A fresh attempt still demands enrolment, and no session exists.
+		const again = await signIn(email);
+		expect(again.res.location).toBe(`/ui/${again.uid}/totp/enroll`);
+		expect(again.res.setCookie ?? '').not.toContain('_session=');
+
+		const user = await getUserStore(bucketId).findByEmail(email);
+		expect(user?.totp).toBeUndefined();
+	});
+
+	/*
+	 * FR-029. Retention has to be a property of the code rather than an accident of what nobody wrote:
+	 * discarding enrolments on the way down would make lowering the bucket a destructive act, and raising
+	 * it again would drag everyone back through setup.
+	 */
+	it('keeps enrolments when the bucket is lowered, and honours them when raised again', async () => {
+		const email = await existingAccount('retained');
+		await raise(true);
+
+		const first = await signIn(email);
+		const page = await getPage(`/ui/${first.uid}/totp/enroll`, first.cookie);
+		const secret = secretFrom(page.text);
+		await postForm(`/ui/${first.uid}/totp/enroll`, first.cookie, {
+			code: codeFor(secret)
+		});
+
+		await raise(false);
+		const lowered = await signIn(email);
+		// Straight through: no code demanded of an enrolled account in a bucket that does not ask.
+		expect(lowered.res.setCookie ?? '').toContain('_session=');
+
+		// The enrolment survived the round trip.
+		const user = await getUserStore(bucketId).findByEmail(email);
+		expect(user?.totp?.secret).toBe(secret);
+
+		await raise(true);
+		const reraised = await signIn(email);
+		// The code step, not enrolment: they never have to set it up twice.
+		expect(reraised.res.location).toBe(`/ui/${reraised.uid}/totp`);
+	});
+});

--- a/test/totp/registration.spec.ts
+++ b/test/totp/registration.spec.ts
@@ -281,6 +281,30 @@ describe('enrolment at registration (US2)', () => {
 		expect(secretFrom(reoffered.text)).not.toBe(secret);
 	});
 
+	/*
+	 * Same race on the enrolment side. Confirming must not report success against a deleted row: the
+	 * caller would write `result.login` and sign someone in as an account that holds no authenticator
+	 * and, in fact, does not exist.
+	 */
+	it('refuses to enrol an account that vanished before the code was confirmed', async () => {
+		const email = `vanishing-enrol-${Math.random()}@x.io`;
+		const { uid, cookie } = await register('totp-required-app', email);
+		const page = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		const secret = secretFrom(page.text);
+
+		const user = await getUserStore(requiredBucketId).findByEmail(email);
+		await getUserStore(requiredBucketId).destroy(user!._id);
+
+		const res = await postForm(`/ui/${uid}/totp/enroll`, cookie, {
+			code: codeFor(secret)
+		});
+
+		expect(res.setCookie ?? '').not.toContain('_session=');
+		expect(res.location).toBe(`/ui/${uid}/login`);
+		// The pending secret is not left addressed to a row that no longer exists.
+		expect(await adapter('TotpEnrollment').find(uid)).toBeUndefined();
+	});
+
 	it('sends someone with no half-finished sign-in back to the login page', async () => {
 		const { uid, cookie } = await startInteraction('totp-required-app');
 		const page = await getPage(`/ui/${uid}/totp/enroll`, cookie);

--- a/test/totp/registration.spec.ts
+++ b/test/totp/registration.spec.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, beforeAll } from 'bun:test';
+import bootstrap, { agent, getHeader } from '../test_helper.ts';
+import { AuthorizationRequest } from '../AuthorizationRequest.ts';
+import {
+	adapter,
+	getBucketStore,
+	getProjectStore,
+	getUserStore,
+	resetAdminMemoryStores
+} from 'lib/adapters/index.ts';
+import { elysia } from 'lib/index.ts';
+import { decodeBase32 } from 'lib/totp/base32.ts';
+import { hotp, stepFor } from 'lib/totp/code.ts';
+import epochTime from 'lib/helpers/epoch_time.ts';
+import { resetSentEmails, sentEmails } from '../mail_capture.ts';
+import { TestAdapter } from 'test/models.js';
+
+const PASSWORD = 'correct horse battery';
+const INVALID_CODE = 'Invalid code';
+
+let requiredBucketId: string;
+let optionalBucketId: string;
+let closedBucketId: string;
+
+async function seedBucket(
+	name: string,
+	clientId: string,
+	fields: Record<string, unknown>
+): Promise<string> {
+	const bucket = await getBucketStore().create({ name, ...fields });
+	const project = await getProjectStore().create({
+		name,
+		slug: `${clientId}-${Math.random()}`
+	});
+	await getProjectStore().update(project._id, {
+		bucketId: bucket._id,
+		clientIds: [clientId]
+	});
+	return bucket._id;
+}
+
+async function startInteraction(clientId: string) {
+	const auth = new AuthorizationRequest({
+		client_id: clientId,
+		scope: 'openid'
+	});
+	const { response } = await agent.auth.get({ query: auth.params });
+	const location = getHeader(response, 'location');
+	const uid = location.split('/')[2];
+	const cookie = response.headers.get('set-cookie');
+	if (!cookie) throw new Error('expected an interaction cookie from /auth');
+	return { uid, cookie };
+}
+
+async function postForm(
+	path: string,
+	cookie: string,
+	fields: Record<string, string>
+) {
+	const res = await elysia.handle(
+		new Request(`http://e.ly${path}`, {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				cookie
+			},
+			body: new URLSearchParams(fields).toString(),
+			redirect: 'manual'
+		})
+	);
+	return {
+		status: res.status,
+		text: await res.text(),
+		location: res.headers.get('location'),
+		setCookie: res.headers.get('set-cookie')
+	};
+}
+
+async function getPage(path: string, cookie?: string) {
+	const res = await elysia.handle(
+		new Request(`http://e.ly${path}`, {
+			headers: cookie ? { cookie } : {}
+		})
+	);
+	return {
+		status: res.status,
+		text: await res.text(),
+		location: res.headers.get('location'),
+		contentType: res.headers.get('content-type') ?? ''
+	};
+}
+
+/*
+ * The Base32 secret the enrolment page is offering, read out of the page's own props script — which is
+ * exactly what an authenticator app would get from the QR beside it, and the only place a test can
+ * legitimately learn it.
+ */
+function secretFrom(html: string): string {
+	const props = /window\.PROPS=(\{.*?\})<\/script>/s.exec(html)?.[1];
+	if (!props) throw new Error('the enrolment page carried no props script');
+	const parsed = JSON.parse(props) as { secretText?: string };
+	if (!parsed.secretText) throw new Error('the props carried no secret');
+	return parsed.secretText.replace(/\s+/g, '');
+}
+
+function codeFor(secret: string, at = epochTime()): string {
+	return hotp(decodeBase32(secret), stepFor(at));
+}
+
+async function register(clientId: string, email: string) {
+	const { uid, cookie } = await startInteraction(clientId);
+	const res = await postForm(`/ui/${uid}/registration`, cookie, {
+		email,
+		password: PASSWORD,
+		confirmPassword: PASSWORD
+	});
+	return { uid, cookie, res };
+}
+
+describe('enrolment at registration (US2)', () => {
+	beforeAll(async () => {
+		await bootstrap(import.meta.url, { config: 'totp' });
+		resetAdminMemoryStores();
+		resetSentEmails();
+		requiredBucketId = await seedBucket('Enrol Required', 'totp-required-app', {
+			totpRequired: true
+		});
+		optionalBucketId = await seedBucket('Enrol Optional', 'totp-optional-app', {
+			totpRequired: false
+		});
+		closedBucketId = await seedBucket('Enrol Closed', 'totp-migrate-app', {
+			totpRequired: true,
+			registrationOpen: false
+		});
+	});
+
+	it('sends a registrant into the enrolment step', async () => {
+		const { uid, res } = await register(
+			'totp-required-app',
+			`enrol-${Math.random()}@x.io`
+		);
+		expect(res.status).toBe(303);
+		expect(res.location).toBe(`/ui/${uid}/totp/enroll`);
+	});
+
+	it('offers a scannable QR and the same secret as text', async () => {
+		const email = `qr-${Math.random()}@x.io`;
+		const { uid, cookie } = await register('totp-required-app', email);
+
+		const page = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		expect(page.status).toBe(200);
+		expect(page.contentType).toContain('text/html');
+
+		// An inline SVG, not a canvas: a canvas is empty until scripts run.
+		expect(page.text).toContain('<svg');
+		// The otpauth URI the QR encodes, carrying the issuer label and the account.
+		expect(page.text).toContain('otpauth://totp/');
+		expect(page.text).toContain(encodeURIComponent(email));
+
+		// And the typed fallback, which is what a camera that will not focus comes down to.
+		const secret = secretFrom(page.text);
+		expect(secret).toMatch(/^[A-Z2-7]{32}$/);
+	});
+
+	it('records nothing against the account until a code proves possession', async () => {
+		const email = `unproved-${Math.random()}@x.io`;
+		await register('totp-required-app', email);
+
+		const user = await getUserStore(requiredBucketId).findByEmail(email);
+		expect(user).toBeTruthy();
+		expect(user?.totp).toBeUndefined();
+	});
+
+	it('completes registration on a correct code', async () => {
+		const email = `done-${Math.random()}@x.io`;
+		const { uid, cookie } = await register('totp-required-app', email);
+		const page = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		const secret = secretFrom(page.text);
+
+		const res = await postForm(`/ui/${uid}/totp/enroll`, cookie, {
+			code: codeFor(secret)
+		});
+		expect(res.status).toBe(303);
+		expect(res.setCookie ?? '').toContain('_session=');
+
+		const user = await getUserStore(requiredBucketId).findByEmail(email);
+		expect(user?.totp?.secret).toBe(secret);
+		expect(user?.totp?.enrolledAt).toBeDefined();
+	});
+
+	/*
+	 * The property that makes a mistyped digit survivable. A fresh secret on every wrong code would mean
+	 * deleting and re-adding the entry in the authenticator app, which is why the pending record is keyed
+	 * by the interaction rather than minted per request.
+	 */
+	it('re-offers the same secret after a wrong code', async () => {
+		const email = `same-secret-${Math.random()}@x.io`;
+		const { uid, cookie } = await register('totp-required-app', email);
+		const first = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		const secret = secretFrom(first.text);
+
+		const rejected = await postForm(`/ui/${uid}/totp/enroll`, cookie, {
+			code: '000001'
+		});
+		expect(rejected.status).toBe(400);
+		expect(rejected.text).toContain(INVALID_CODE);
+		expect(secretFrom(rejected.text)).toBe(secret);
+
+		// A reload offers it too, rather than rotating under the person mid-setup.
+		const reloaded = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		expect(secretFrom(reloaded.text)).toBe(secret);
+
+		// And the secret that was on screen all along is the one that works.
+		const accepted = await postForm(`/ui/${uid}/totp/enroll`, cookie, {
+			code: codeFor(secret)
+		});
+		expect(accepted.status).toBe(303);
+	});
+
+	it('leaves an abandoned enrolment unable to sign in with the password alone', async () => {
+		const email = `abandoned-${Math.random()}@x.io`;
+		await register('totp-required-app', email);
+
+		// A completely fresh sign-in, as if they closed the tab and came back later.
+		const { uid, cookie } = await startInteraction('totp-required-app');
+		const res = await postForm(`/ui/${uid}/login`, cookie, {
+			username: email,
+			password: PASSWORD
+		});
+		expect(res.status).toBe(303);
+		expect(res.location).toBe(`/ui/${uid}/totp/enroll`);
+		expect(res.setCookie ?? '').not.toContain('_session=');
+	});
+
+	it('signs the person in with two factors recorded', async () => {
+		const email = `amr-enrol-${Math.random()}@x.io`;
+		const { uid, cookie } = await register('totp-required-app', email);
+		const page = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+
+		const res = await postForm(`/ui/${uid}/totp/enroll`, cookie, {
+			code: codeFor(secretFrom(page.text))
+		});
+		expect(res.location ?? '').toMatch(/\/consent$|\/callback/);
+	});
+
+	it('destroys the pending record once it is confirmed', async () => {
+		const email = `cleanup-${Math.random()}@x.io`;
+		const { uid, cookie } = await register('totp-required-app', email);
+		const page = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		expect(await adapter('TotpEnrollment').find(uid)).toBeDefined();
+
+		await postForm(`/ui/${uid}/totp/enroll`, cookie, {
+			code: codeFor(secretFrom(page.text))
+		});
+		expect(await adapter('TotpEnrollment').find(uid)).toBeUndefined();
+	});
+
+	it('offers a fresh secret once the pending one has expired', async () => {
+		const email = `expired-${Math.random()}@x.io`;
+		const { uid, cookie } = await register('totp-required-app', email);
+		const first = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		const secret = secretFrom(first.text);
+
+		/*
+		 * Age the live record, which is exactly the state MongoDB's lazy TTL monitor leaves behind — an
+		 * expired document still findable for up to a minute. Written through `syncUpdate` because the
+		 * front door refuses it: `TestAdapter.upsert` asserts the written `exp` matches the TTL it was
+		 * given, so an inconsistent record cannot be forged that way.
+		 */
+		TestAdapter.for('TotpEnrollment').syncUpdate(uid, {
+			exp: epochTime() - 1
+		});
+
+		const res = await postForm(`/ui/${uid}/totp/enroll`, cookie, {
+			code: codeFor(secret)
+		});
+		expect(res.status).toBe(303);
+		expect(res.location).toBe(`/ui/${uid}/totp/enroll`);
+
+		const reoffered = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		expect(secretFrom(reoffered.text)).not.toBe(secret);
+	});
+
+	it('sends someone with no half-finished sign-in back to the login page', async () => {
+		const { uid, cookie } = await startInteraction('totp-required-app');
+		const page = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		expect(page.status).toBe(303);
+		expect(page.location).toBe(`/ui/${uid}/login`);
+	});
+
+	it('generates no secret for a bucket that has closed registration', async () => {
+		const email = `closed-${Math.random()}@x.io`;
+		const { uid, res } = await register('totp-migrate-app', email);
+		expect(res.status).toBe(403);
+		expect(await adapter('TotpEnrollment').find(uid)).toBeUndefined();
+		expect(await getUserStore(closedBucketId).findByEmail(email)).toBeNull();
+	});
+
+	describe('a bucket that does not require the second factor', () => {
+		it('registers exactly as it did before, with no enrolment step', async () => {
+			const email = `plain-${Math.random()}@x.io`;
+			const { uid, res } = await register('totp-optional-app', email);
+			expect(res.status).toBe(303);
+			expect(res.location).toBe(`/ui/${uid}/login`);
+
+			const user = await getUserStore(optionalBucketId).findByEmail(email);
+			expect(user).toBeTruthy();
+			expect(user?.totp).toBeUndefined();
+			expect(await adapter('TotpEnrollment').find(uid)).toBeUndefined();
+		});
+	});
+
+	describe('composed with email verification', () => {
+		let bothBucketId: string;
+
+		beforeAll(async () => {
+			bothBucketId = await seedBucket('Both', 'totp-admin-app', {
+				totpRequired: true,
+				emailVerificationRequired: true,
+				verificationMethod: 'link'
+			});
+		});
+
+		/*
+		 * Verification runs first and keeps its own redirect, so the two requirements compose rather than
+		 * one replacing the other: the address is proved now, the authenticator at the first sign-in.
+		 */
+		it('sends the verification mail and keeps its redirect', async () => {
+			const email = `both-${Math.random()}@x.io`;
+			const before = sentEmails.length;
+			const { uid, res } = await register('totp-admin-app', email);
+
+			expect(sentEmails.length).toBe(before + 1);
+			expect(res.location).toContain(`/ui/${uid}/login`);
+
+			const user = await getUserStore(bothBucketId).findByEmail(email);
+			expect(user?.verified).toBe(false);
+			expect(user?.totp).toBeUndefined();
+		});
+	});
+});

--- a/test/totp/signin.spec.ts
+++ b/test/totp/signin.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'bun:test';
+import { describe, it, expect, beforeAll, spyOn } from 'bun:test';
 import bootstrap, { agent, getHeader } from '../test_helper.ts';
 import { AuthorizationRequest } from '../AuthorizationRequest.ts';
 import {
@@ -17,6 +17,7 @@ import {
 	MAX_ATTEMPTS_PER_INTERACTION
 } from 'lib/totp/consts.ts';
 import epochTime from 'lib/helpers/epoch_time.ts';
+import { TestAdapter } from 'test/models.js';
 
 const PASSWORD = 'correct horse battery';
 const SECRET = encodeBase32(Buffer.from('12345678901234567890', 'ascii'));
@@ -302,6 +303,61 @@ describe('second factor at sign-in (US3)', () => {
 			`${requiredBucketId}:${user._id}`
 		);
 		expect(record).toBeDefined();
+		/*
+		 * A longer budget than the 5s default, and not because anything here is slow by accident: driving
+		 * the cap means ACCOUNT_FAILURE_CAP full sign-ins, each paying for a real argon2 verification. It
+		 * ran at ~2.1s of the default budget when written, which is close enough to the edge that another
+		 * account in the in-memory store, or a loaded machine, tips it over — a flake that says nothing
+		 * about the throttle.
+		 */
+	}, 30_000);
+
+	/* The account is deleted between the password and the code — an operator acting mid-sign-in. */
+	it('refuses when the account is gone by the time the code arrives', async () => {
+		const email = `vanishing-${Math.random()}@x.io`;
+		const user = await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		await getUserStore(requiredBucketId).destroy(user._id);
+
+		const res = await postForm(`/ui/${uid}/totp`, cookie, {
+			code: currentCode()
+		});
+
+		expect(res.setCookie ?? '').not.toContain('_session=');
+		// Routed onward to enrolment, which finds no account either and returns them to the login door.
+		expect(res.location).toBe(`/ui/${uid}/totp/enroll`);
+
+		const next = await getPage(`/ui/${uid}/totp/enroll`, cookie);
+		expect(next.location).toBe(`/ui/${uid}/login`);
+	});
+
+	/*
+	 * The narrower race the one above cannot reach: the row survives the read at the top of
+	 * verifyForAccount and is gone by the write that advances `lastStep`. Only a failed write can
+	 * express it, so the write is what this drives.
+	 *
+	 * Worth its own test rather than trusting the deletion case, because the two take different exits —
+	 * that one returns before ever verifying a code, so it would pass with the guard deleted.
+	 */
+	it('refuses when the replay guard cannot be advanced', async () => {
+		const email = `no-advance-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		const store = getUserStore(requiredBucketId);
+		const update = spyOn(store, 'update').mockResolvedValueOnce(null);
+		try {
+			const res = await postForm(`/ui/${uid}/totp`, cookie, {
+				code: currentCode()
+			});
+			expect(update).toHaveBeenCalled();
+			// Not signed in on a verification whose replay guard never moved.
+			expect(res.setCookie ?? '').not.toContain('_session=');
+			expect(res.location).toBe(`/ui/${uid}/totp/enroll`);
+		} finally {
+			update.mockRestore();
+		}
 	});
 
 	it('sends someone with no half-finished sign-in back to the login page', async () => {
@@ -318,6 +374,45 @@ describe('second factor at sign-in (US3)', () => {
 		});
 		expect(res.status).toBe(303);
 		expect(res.location).toContain(`/ui/${uid}/login`);
+	});
+
+	/*
+	 * A wrong code re-saves the interaction to bump its attempt counter, and that save must never be
+	 * handed a non-positive lifetime. The consequence lives in MongoAdapter.upsert, where `expiresIn`
+	 * is tested for truthiness: a TTL of 0 writes no `expiresAt` at all and leaves an interaction that
+	 * should be seconds from death non-expiring, while a negative one back-dates it.
+	 *
+	 * The TTL is asserted rather than its effect, deliberately. The effect is MongoAdapter's, and the
+	 * TestAdapter does not share it — it stores the record either way, so an assertion on what was
+	 * stored passes with the clamp removed and proves nothing. What both adapters do share is the
+	 * argument, so that is what this pins.
+	 */
+	it('never saves an interaction with a non-positive lifetime', async () => {
+		const email = `at-expiry-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		// Exactly at expiry: the unclamped arithmetic yields 0.
+		TestAdapter.for('Interaction').syncUpdate(uid, { exp: epochTime() });
+
+		const store = adapter('Interaction');
+		const ttls: unknown[] = [];
+		const upsert = spyOn(store, 'upsert').mockImplementation(
+			async (id: string, payload: unknown, expiresIn?: number) => {
+				ttls.push(expiresIn);
+			}
+		);
+		try {
+			await postForm(`/ui/${uid}/totp`, cookie, { code: '000001' });
+		} finally {
+			upsert.mockRestore();
+		}
+
+		expect(ttls.length).toBeGreaterThan(0);
+		for (const ttl of ttls) {
+			expect(typeof ttl).toBe('number');
+			expect(ttl as number).toBeGreaterThanOrEqual(1);
+		}
 	});
 
 	it('refuses the code page without the interaction cookie', async () => {

--- a/test/totp/signin.spec.ts
+++ b/test/totp/signin.spec.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeAll } from 'bun:test';
+import bootstrap, { agent, getHeader } from '../test_helper.ts';
+import { AuthorizationRequest } from '../AuthorizationRequest.ts';
+import {
+	adapter,
+	getBucketStore,
+	getProjectStore,
+	getUserStore,
+	resetAdminMemoryStores
+} from 'lib/adapters/index.ts';
+import { elysia } from 'lib/index.ts';
+import { encodeBase32, decodeBase32 } from 'lib/totp/base32.ts';
+import { Session } from 'lib/models/session.ts';
+import { hotp, stepFor } from 'lib/totp/code.ts';
+import {
+	ACCOUNT_FAILURE_CAP,
+	MAX_ATTEMPTS_PER_INTERACTION
+} from 'lib/totp/consts.ts';
+import epochTime from 'lib/helpers/epoch_time.ts';
+
+const PASSWORD = 'correct horse battery';
+const SECRET = encodeBase32(Buffer.from('12345678901234567890', 'ascii'));
+
+// The one message every failed code produces, whatever the reason.
+const INVALID_CODE = 'Invalid code';
+const INVALID_CREDENTIALS = 'Invalid username or password';
+
+let requiredBucketId: string;
+let optionalBucketId: string;
+
+/*
+ * What an authenticator app would be showing right now. Uses the same primitives the server does —
+ * they are proved against the RFC vectors in algorithm.spec.ts, so a bug in them fails there rather
+ * than making every test in this file agree with the server about something wrong.
+ */
+function currentCode(at = epochTime()): string {
+	return hotp(decodeBase32(SECRET), stepFor(at));
+}
+
+async function seedBucket(
+	name: string,
+	clientId: string,
+	fields: Record<string, unknown>
+): Promise<string> {
+	const bucket = await getBucketStore().create({ name, ...fields });
+	const project = await getProjectStore().create({
+		name,
+		slug: `${clientId}-${Math.random()}`
+	});
+	await getProjectStore().update(project._id, {
+		bucketId: bucket._id,
+		clientIds: [clientId]
+	});
+	return bucket._id;
+}
+
+async function startInteraction(clientId: string) {
+	const auth = new AuthorizationRequest({
+		client_id: clientId,
+		scope: 'openid'
+	});
+	const { response } = await agent.auth.get({ query: auth.params });
+	const location = getHeader(response, 'location');
+	const uid = location.split('/')[2];
+	const cookie = response.headers.get('set-cookie');
+	if (!cookie) throw new Error('expected an interaction cookie from /auth');
+	return { uid, cookie };
+}
+
+async function postForm(
+	path: string,
+	cookie: string,
+	fields: Record<string, string>
+) {
+	const res = await elysia.handle(
+		new Request(`http://e.ly${path}`, {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				cookie
+			},
+			body: new URLSearchParams(fields).toString(),
+			redirect: 'manual'
+		})
+	);
+	return {
+		status: res.status,
+		text: await res.text(),
+		location: res.headers.get('location'),
+		setCookie: res.headers.get('set-cookie')
+	};
+}
+
+async function getPage(path: string, cookie?: string) {
+	const res = await elysia.handle(
+		new Request(`http://e.ly${path}`, {
+			headers: cookie ? { cookie } : {}
+		})
+	);
+	return {
+		status: res.status,
+		text: await res.text(),
+		location: res.headers.get('location'),
+		csp: res.headers.get('content-security-policy'),
+		contentType: res.headers.get('content-type') ?? ''
+	};
+}
+
+/*
+ * The `amr` recorded on a session, read back through the model.
+ *
+ * Narrowed at this one call site rather than by widening the model layer, exactly as
+ * lib/admin/auth/login.ts narrows `Session.tryFind` and for the same pre-existing reason: `BaseModel`'s
+ * `this` constraint does not admit `Session`'s own constructor, and its payload type collapses to the
+ * base shape on the way out.
+ */
+async function amrOf(sessionId: string): Promise<string[] | undefined> {
+	const session = await (
+		Session as unknown as {
+			find(id: string): Promise<{ payload: { amr?: string[] } } | undefined>;
+		}
+	).find(sessionId);
+	return session?.payload.amr;
+}
+
+/* An account that already holds an authenticator, without driving the enrolment flow to create one. */
+async function seedEnrolled(bucketId: string, email: string) {
+	const user = await getUserStore(bucketId).create(
+		email,
+		await Bun.password.hash(PASSWORD),
+		[],
+		true
+	);
+	await getUserStore(bucketId).update(user._id, {
+		totp: { secret: SECRET, enrolledAt: new Date(), lastStep: 0 }
+	});
+	return user;
+}
+
+/*
+ * What "the sign-in completed" looks like from the outside: a session cookie was issued and the
+ * interaction moved on to the next prompt. Asserted as consent-or-callback rather than pinned to the
+ * callback, because a first sign-in still has consent to collect — the important part is that the
+ * request left the authentication step at all.
+ */
+function expectSignedIn(res: {
+	status: number;
+	location: string | null;
+	setCookie: string | null;
+}) {
+	expect(res.status).toBe(303);
+	expect(res.setCookie ?? '').toContain('_session=');
+	expect(res.location ?? '').toMatch(/\/consent$|\/callback/);
+}
+
+/* Password accepted, code not yet supplied. */
+async function passwordStep(clientId: string, email: string) {
+	const { uid, cookie } = await startInteraction(clientId);
+	const res = await postForm(`/ui/${uid}/login`, cookie, {
+		username: email,
+		password: PASSWORD
+	});
+	return { uid, cookie, res };
+}
+
+describe('second factor at sign-in (US3)', () => {
+	beforeAll(async () => {
+		await bootstrap(import.meta.url, { config: 'totp' });
+		resetAdminMemoryStores();
+		requiredBucketId = await seedBucket('TOTP Required', 'totp-required-app', {
+			totpRequired: true
+		});
+		optionalBucketId = await seedBucket('TOTP Optional', 'totp-optional-app', {
+			totpRequired: false
+		});
+	});
+
+	it('does not sign the person in on a correct password alone', async () => {
+		const email = `pwd-only-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { res } = await passwordStep('totp-required-app', email);
+
+		// Sent onward to the code step, and nothing was established on the way.
+		expect(res.status).toBe(303);
+		expect(res.location).toContain('/totp');
+		expect(res.setCookie ?? '').not.toContain('_session=');
+	});
+
+	it('leaves the authorization request unfinished until the code is supplied', async () => {
+		const email = `unfinished-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, res } = await passwordStep('totp-required-app', email);
+
+		// Not handed back to the client, and no session issued: the redirect stays inside the interaction.
+		expect(res.location).toContain(`/ui/${uid}/totp`);
+		expect(res.setCookie ?? '').not.toContain('_session=');
+	});
+
+	it('renders a code page carrying no account detail', async () => {
+		const email = `codepage-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		const page = await getPage(`/ui/${uid}/totp`, cookie);
+		expect(page.status).toBe(200);
+		expect(page.contentType).toContain('text/html');
+		expect(page.csp).toBeTruthy();
+		// The email is not shown: the page adds nothing by naming it and may be read over a shoulder.
+		expect(page.text).not.toContain(email);
+	});
+
+	it('completes the sign-in on a correct code', async () => {
+		const email = `good-code-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		const res = await postForm(`/ui/${uid}/totp`, cookie, {
+			code: currentCode()
+		});
+		expectSignedIn(res);
+	});
+
+	it('refuses a wrong code without revealing the password was right', async () => {
+		const email = `bad-code-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		const res = await postForm(`/ui/${uid}/totp`, cookie, { code: '000001' });
+		expect(res.status).toBe(400);
+		expect(res.text).toContain(INVALID_CODE);
+		expect(res.text).not.toContain(INVALID_CREDENTIALS);
+		expect(res.location).toBeNull();
+	});
+
+	it('refuses a code that was already spent, inside its own window', async () => {
+		const email = `replay-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const code = currentCode();
+
+		const first = await passwordStep('totp-required-app', email);
+		const ok = await postForm(`/ui/${first.uid}/totp`, first.cookie, { code });
+		expectSignedIn(ok);
+
+		// A second sign-in, same 30-second window, same code.
+		const second = await passwordStep('totp-required-app', email);
+		const replay = await postForm(`/ui/${second.uid}/totp`, second.cookie, {
+			code
+		});
+		expect(replay.status).toBe(400);
+		expect(replay.text).toContain(INVALID_CODE);
+	});
+
+	it('accepts a code from the adjacent step, tolerating clock drift', async () => {
+		const email = `drift-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		const previousStep = hotp(decodeBase32(SECRET), stepFor(epochTime()) - 1);
+		const res = await postForm(`/ui/${uid}/totp`, cookie, {
+			code: previousStep
+		});
+		expectSignedIn(res);
+	});
+
+	it('throttles repeated wrong codes within one sign-in attempt', async () => {
+		const email = `throttle-int-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		for (let i = 0; i < MAX_ATTEMPTS_PER_INTERACTION; i += 1) {
+			await postForm(`/ui/${uid}/totp`, cookie, { code: '000001' });
+		}
+
+		// Even the right code is refused now, and the wording does not change.
+		const res = await postForm(`/ui/${uid}/totp`, cookie, {
+			code: currentCode()
+		});
+		expect(res.status).toBe(400);
+		expect(res.text).toContain(INVALID_CODE);
+	});
+
+	// The per-interaction counter alone is defeated by starting a new interaction, which costs one request.
+	it('throttles per account across sign-in attempts', async () => {
+		const email = `throttle-acct-${Math.random()}@x.io`;
+		const user = await seedEnrolled(requiredBucketId, email);
+
+		for (let i = 0; i < ACCOUNT_FAILURE_CAP; i += 1) {
+			const attempt = await passwordStep('totp-required-app', email);
+			await postForm(`/ui/${attempt.uid}/totp`, attempt.cookie, {
+				code: '000001'
+			});
+		}
+
+		const fresh = await passwordStep('totp-required-app', email);
+		const res = await postForm(`/ui/${fresh.uid}/totp`, fresh.cookie, {
+			code: currentCode()
+		});
+		expect(res.status).toBe(400);
+		expect(res.text).toContain(INVALID_CODE);
+
+		const record = await adapter('TotpAttempt').find(
+			`${requiredBucketId}:${user._id}`
+		);
+		expect(record).toBeDefined();
+	});
+
+	it('sends someone with no half-finished sign-in back to the login page', async () => {
+		const { uid, cookie } = await startInteraction('totp-required-app');
+		const page = await getPage(`/ui/${uid}/totp`, cookie);
+		expect(page.status).toBe(303);
+		expect(page.location).toContain(`/ui/${uid}/login`);
+	});
+
+	it('refuses a code POST with no half-finished sign-in', async () => {
+		const { uid, cookie } = await startInteraction('totp-required-app');
+		const res = await postForm(`/ui/${uid}/totp`, cookie, {
+			code: currentCode()
+		});
+		expect(res.status).toBe(303);
+		expect(res.location).toContain(`/ui/${uid}/login`);
+	});
+
+	it('refuses the code page without the interaction cookie', async () => {
+		const email = `nocookie-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid } = await passwordStep('totp-required-app', email);
+
+		const page = await getPage(`/ui/${uid}/totp`);
+		expect(page.status).toBeGreaterThanOrEqual(400);
+	});
+
+	it('still refuses an inactive account, before the code step is reached', async () => {
+		const email = `inactive-${Math.random()}@x.io`;
+		const user = await seedEnrolled(requiredBucketId, email);
+		await getUserStore(requiredBucketId).update(user._id, { active: false });
+
+		const { res } = await passwordStep('totp-required-app', email);
+		expect(res.status).toBe(400);
+		expect(res.text).toContain(INVALID_CREDENTIALS);
+	});
+
+	it('still refuses a wrong password, with no hint that an enrolment exists', async () => {
+		const email = `wrongpwd-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await startInteraction('totp-required-app');
+
+		const res = await postForm(`/ui/${uid}/login`, cookie, {
+			username: email,
+			password: 'not the password'
+		});
+		expect(res.status).toBe(400);
+		expect(res.text).toContain(INVALID_CREDENTIALS);
+		expect(res.text).not.toContain(INVALID_CODE);
+	});
+
+	/*
+	 * FR-023. The session is where `amr` is recorded, and lib/helpers/process_response_types.ts reads it
+	 * from there onto the ID token — so asserting the session carries it is asserting the whole chain,
+	 * without exchanging a code for tokens to read a claim this server already puts there for every
+	 * other `amr` producer.
+	 */
+	it('records two factors on the resulting session', async () => {
+		const email = `amr-${Math.random()}@x.io`;
+		await seedEnrolled(requiredBucketId, email);
+		const { uid, cookie } = await passwordStep('totp-required-app', email);
+
+		const res = await postForm(`/ui/${uid}/totp`, cookie, {
+			code: currentCode()
+		});
+		expectSignedIn(res);
+
+		const sessionId = /_session=([^;]+)/.exec(res.setCookie ?? '')?.[1];
+		expect(sessionId).toBeTruthy();
+		expect(await amrOf(sessionId as string)).toEqual(['pwd', 'otp']);
+	});
+
+	it('leaves amr absent on a password-only sign-in, changing nothing for it', async () => {
+		const email = `amr-absent-${Math.random()}@x.io`;
+		await getUserStore(optionalBucketId).create(
+			email,
+			await Bun.password.hash(PASSWORD),
+			[],
+			true
+		);
+		const { res } = await passwordStep('totp-optional-app', email);
+
+		const sessionId = /_session=([^;]+)/.exec(res.setCookie ?? '')?.[1];
+		expect(await amrOf(sessionId as string)).toBeUndefined();
+	});
+
+	describe('a bucket that does not require the second factor', () => {
+		it('signs in on the password alone, exactly as before', async () => {
+			const email = `optional-${Math.random()}@x.io`;
+			await getUserStore(optionalBucketId).create(
+				email,
+				await Bun.password.hash(PASSWORD),
+				[],
+				true
+			);
+			const { res } = await passwordStep('totp-optional-app', email);
+			expectSignedIn(res);
+		});
+
+		// FR-024: an enrolled account in a bucket that does not require it is not asked for a code.
+		it('asks no code even of an account that happens to be enrolled', async () => {
+			const email = `optional-enrolled-${Math.random()}@x.io`;
+			await seedEnrolled(optionalBucketId, email);
+			const { res } = await passwordStep('totp-optional-app', email);
+			expectSignedIn(res);
+		});
+	});
+});

--- a/test/totp/totp.config.ts
+++ b/test/totp/totp.config.ts
@@ -1,0 +1,44 @@
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+/*
+ * One client per bucket state, so a spec never has to mutate a bucket another spec is using — the
+ * arrangement test/interaction_ui/pages.config.ts settled on for the same reason. The buckets
+ * themselves are seeded per group in each spec's beforeAll, because their flags are what
+ * distinguishes the groups.
+ */
+export const clients = [
+	{
+		clientId: 'totp-required-app',
+		token_endpoint_auth_method: 'none',
+		grantTypes: ['authorization_code'],
+		responseTypes: ['code'],
+		redirectUris: ['http://e.ly/totp-required/callback']
+	},
+	{
+		clientId: 'totp-optional-app',
+		token_endpoint_auth_method: 'none',
+		grantTypes: ['authorization_code'],
+		responseTypes: ['code'],
+		redirectUris: ['http://e.ly/totp-optional/callback']
+	},
+	{
+		clientId: 'totp-migrate-app',
+		token_endpoint_auth_method: 'none',
+		grantTypes: ['authorization_code'],
+		responseTypes: ['code'],
+		redirectUris: ['http://e.ly/totp-migrate/callback']
+	},
+	{
+		clientId: 'totp-admin-app',
+		token_endpoint_auth_method: 'none',
+		grantTypes: ['authorization_code'],
+		responseTypes: ['code'],
+		redirectUris: ['http://e.ly/totp-admin/callback']
+	}
+];
+
+export default {
+	config
+};

--- a/wiki/concepts/totp-second-factor.md
+++ b/wiki/concepts/totp-second-factor.md
@@ -1,0 +1,145 @@
+---
+type: concept
+title: 'The TOTP second factor'
+tags: [architecture, contract, gotcha]
+sources: [oauth-server-codebase]
+created: 2026-08-27
+updated: 2026-08-27
+graph:
+  node_type: concept
+  relationships:
+    - predicate: depends_on
+      object: concept:interaction-page-families
+      source: oauth-server-codebase
+      evidence: "case 'totp': return <TotpPage uid={calculateUid()} mode=\"verify\" {...props} />;"
+      confidence: high
+      status: current
+---
+
+# The TOTP second factor
+
+A bucket may require that a password sign-in also carry a six-digit code from an authenticator app. The
+requirement is one boolean, `UserBucket.totpRequired`; everything else follows from where the state is
+put, and each of those placements buys a guarantee that would otherwise have to be enforced by code
+somebody remembers to write.
+
+## The algorithm is in the repository, not in a dependency
+
+`lib/totp/` implements RFC 4226 and RFC 6238 over `node:crypto` — about eighty lines across `base32.ts`
+and `code.ts`. The reason is not minimalism. Both RFCs publish exact test vectors (RFC 4226 Appendix D,
+RFC 6238 Appendix B), so conformance is provable **against the specification itself** rather than
+against a library's interpretation of it, which is what Principle I asks for and what no dependency can
+offer. `test/totp/algorithm.spec.ts` is that proof.
+
+`verifyAt` takes the time as an argument rather than reading a clock. That is what makes the Appendix B
+vectors testable with no fake clock and no injected time source, and it is why the function is pure.
+
+**HMAC-SHA1, deliberately.** RFC 6238 permits SHA-256 and SHA-512, and the `otpauth://` URI has an
+`algorithm=` parameter to say which — but Google Authenticator and several other widely deployed apps
+ignore that parameter and assume SHA-1 unconditionally. An enrolment those apps compute wrong codes for
+is a failed enrolment the person cannot diagnose. The choice costs nothing: HMAC does not rest on the
+collision resistance SHA-1 lost.
+
+## Four placements, four free guarantees
+
+| State | Where it lives | What that buys |
+|---|---|---|
+| The standing enrolment | `User.totp`, embedded | Deletion integrity. The account cascade destroys the row and bucket deletion destroys the area, so no cascade arm knows the field exists — the same reasoning `federated` records. |
+| The half-finished sign-in | `InteractionPayload.secondFactor` | Expiry. The interaction already has a TTL, so a sign-in stuck between the password and the code dies with the attempt it belongs to. No expiry logic exists for it. |
+| The unproved secret | `TotpEnrollment`, **keyed by the interaction uid** | No handle to leak or guess; completable only from inside the interaction that started it; and the same secret re-offered on every reload. |
+| The failure window | `TotpAttempt`, id `${bucketId}:${accountId}` | Survives across interactions, which is the only way the throttle means anything. |
+
+**Present ⇔ enrolled.** There is no `enrolled` boolean beside the secret. Two fields claiming to say the
+same thing disagree after the first edit — the rule `passwordLogin` states about federation
+availability, applied again.
+
+## Why the bucket field is a boolean and not an enum
+
+`signInMethod: 'password' | 'password_totp'` reads better in isolation and is wrong here. `UserBucket`
+already carries `passwordLogin`, whose own comment records the rule: *"Two fields that both claim to say
+whether federation works is the shape that disagrees after the first edit."* An enum whose values both
+begin with `password` is a second field claiming to say whether the password door is open. As a boolean
+the two compose — `passwordLogin` says whether the door exists, `totpRequired` says whether it needs two
+keys — and "permitted but inert when password login is off" becomes a plain consequence rather than a
+special case. The admin route says so in an `advisory` rather than refusing.
+
+## One enrolment flow, entered from two places
+
+A registrant in a requiring bucket and an existing account in a bucket that was just raised are the same
+situation: neither holds an authenticator, and both must get one before their sign-in completes. The
+login POST forks on `user.totp ? 'totp' : 'totp/enroll'` and that single line is the whole of the
+migration story — bringing existing accounts under the requirement needed no code of its own, and
+`test/totp/migration.spec.ts` passed the first time it ran.
+
+It also makes abandonment safe for free. A registrant who closes the tab mid-enrolment leaves an account
+that exists and is unenrolled; because the bucket requires the factor, their next sign-in is routed
+straight back to enrolment. Nothing has to clean up.
+
+## The secret cannot be hashed, so it must never be read
+
+TOTP verification is symmetric. Unlike a password there is no one-way form to store, so the only
+available protection is that the value never appears in a read. `presentUser`
+(`lib/admin/users-end/routes.ts`) is that protection, and it lives in one function rather than at four
+call sites for a recorded reason: a presenter somebody forgets on one route is exactly how every
+administrator came to be handed every bucket's federation secrets. It substitutes `totpEnrolled` and
+`totpEnrolledAt`, which is everything an operator legitimately needs.
+
+`test/mcp/secrecy.spec.ts` sweeps every published read for this, which is why that sweep iterates rather
+than checking the ones somebody thought of.
+
+## Two guards that only exist in the failure path
+
+**The replay guard.** `verifyForAccount` writes the accepted step to `user.totp.lastStep`, and a code at
+or below it is refused. This is the easiest part of the design to lose: implement verification as a pure
+predicate and it disappears, leaving a code observed in flight usable for the rest of its ~90-second
+band. `verifyAt` returns the matching **step** rather than a boolean precisely so the guard is
+expressible.
+
+**Two throttles, not one.** A counter on the interaction alone is defeated by starting a new interaction,
+which costs an attacker a single request — hence the per-account window as well. Every failure answers
+with the same words (`Invalid code`), throttled included: a distinct "too many attempts" tells someone
+guessing that the account is real and that their guesses are landing.
+
+**No account window on enrolment**, only the per-interaction cap. The pending secret already expires on
+its own, and an account-wide lockout there would let a stranger who knows an email stop a real person
+from ever enrolling — the throttle would become the attack.
+
+## What deliberately did not change
+
+`amr` is set to `['pwd', 'otp']` on a two-factor sign-in and a password-only sign-in is left carrying no
+`amr` at all. Stamping `['pwd']` on the latter would be an observable change to the ID token of every
+bucket that does not use this feature, so the test a relying party makes is "does `amr` contain `otp`".
+Both values are registered in RFC 8176. `acr` is not set and `acr_values` requests are not honoured —
+there is no registered value meaning "two factors".
+
+Federated sign-in is never gated. The upstream provider owns its own factor policy, mirroring the
+existing split where `passwordLogin` governs password doors and federation is enabled per provider.
+
+A password reset neither clears nor bypasses an enrolment: a reset proves an address, and the next
+sign-in still asks for a code.
+
+## Two things found on the way
+
+`Interaction.persist()` cannot work and never could: its guard tests `this.exp` while the value lives at
+`this.payload.exp` (`lib/models/base_model.ts`), so it throws *"persist can only be called on previously
+persisted Interactions"* for every interaction that has in fact been persisted. It had no callers, which
+is why nothing noticed. `lib/interactions/index.ts` uses a local `persistInteraction` written the way
+`lib/actions/authorization/resume.ts` already writes it.
+
+The `MongoDB` user store's `update` now splits its patch into `$set` and `$unset`. The driver drops
+undefined values from `$set`, so clearing an enrolment through it would have left the secret in place —
+an account still verifying against an authenticator the operator believed they had revoked, with nothing
+failing anywhere to reveal it.
+
+## Related
+
+- [[interaction-page-families]] — the enrolment and code pages are antd-family, and both hydrate through
+  one `'totp'` arm distinguished by a prop, because the page name comes from the URL path.
+- [[self-service-password-reset]] — the TTL'd-challenge pattern this follows, including comparing expiry
+  in code rather than trusting MongoDB's lazy TTL monitor.
+- [[admin-audit-trail]] — entries carry field *names* and never values, which is why clearing an
+  enrolment records the act and nothing else.
+- [[feature-flag-gating]] — this is bucket state rather than a feature flag, and deliberately so.
+- [[html-response-security-policy]] — both new pages build through `htmlResponse`; the QR is inline SVG
+  and needs no directive.
+- [[token-payload-access-contract]] — `amr` reaches the ID token via `session.payload.amr`.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -45,6 +45,7 @@ When this file exceeds ~300 lines or the wiki passes ~150 pages, shard into `wik
 - [[upstream-federation]] — a bucket may accept sign-in through external OIDC providers; the flow is three hops because the interaction cookie provably cannot survive the trip to an upstream, both round-trip records are keyed by a digest of the value they never store, and linking to an existing account needs operator trust *and* a verified assertion.
 - [[rich-authorization-requests]] — `authorization_details` end to end on the code and refresh flows; the declared parameter schema is a runtime coercion contract, and details reach a token only when a resource server resolves.
 - [[token-payload-access-contract]] — model state lives under `.payload.*`; reading a bare field yields `undefined` silently, and payload schemas are composed per token type.
+- [[totp-second-factor]] — one bucket boolean turns a password door into a two-key one; the algorithm is in-repo because the RFCs publish test vectors, and four placements of state buy deletion integrity, expiry, un-guessable enrolment and a throttle that survives a new interaction for free.
 
 ## Synthesis
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -16,3 +16,5 @@ Operations:
 ## [2026-07-31] ingest | OAuth server codebase (lib/) at commit 2125ad0 — first real ingest. Pilot pass: 1 source page + 5 pages on durable subsystem contracts (token payload access, client identity, account resolution, feature-flag gating, eventBus).
 
 ## [2026-08-27] ingest | Admin console sign-out fix: new page on cookie Path identity (`remove()` omits Path); `admin-console-signin` gains the sign-out half — two sessions, and why not RP-initiated logout.
+
+## [2026-08-27] ingest | TOTP second factor (spec 027): new concept page on the bucket-level second factor — why the algorithm is in-repo (published RFC vectors beat a dependency), why the bucket field is a boolean beside `passwordLogin` rather than an enum replacing it, and the four state placements that buy deletion integrity, expiry, un-guessable enrolment and a cross-interaction throttle. Records two incidental findings: `Interaction.persist()` has never been able to succeed, and the Mongo user store's `$set`-only patch could not clear a field.


### PR DESCRIPTION
A user bucket gains `totpRequired`. When set, a password sign-in to that bucket completes only after a current six-digit code from an authenticator app; anyone not yet enrolled — a new registrant, or an existing account in a bucket that was just raised — goes through the same enrolment step first. Defaulted `false` on read in both adapters, so nothing changes for a bucket that predates the field.

## Design decisions worth reviewing

**The algorithm is in-repo, not a dependency.** RFC 4226/6238 over `node:crypto`, ~80 lines. Both RFCs publish exact test vectors, so conformance is provable against the specification itself rather than a library's reading of it (Principle I). HMAC-SHA1 is a documented deviation with an inline justification: widely deployed authenticator apps ignore the otpauth `algorithm=` parameter and assume it.

**A boolean beside `passwordLogin`, not an enum replacing it.** An enum whose values both begin with `password` would be a second field claiming to say whether the password door is open — the exact shape `passwordLogin`'s own comment warns disagrees after the first edit.

**Four state placements, each buying a guarantee:**

| State | Where | What it buys |
|---|---|---|
| Standing enrolment | `User.totp`, embedded | Deletion integrity — no new cascade arm |
| Half-finished sign-in | `InteractionPayload.secondFactor` | Expiry, from the interaction's own TTL |
| Unproved secret | `TotpEnrollment`, keyed by interaction uid | No handle to leak; same secret re-offered on a wrong code |
| Failure window | `TotpAttempt` | Survives a new interaction, which is the only way a throttle means anything |

**One enrolment flow, two entry points.** Because an unenrolled account in a requiring bucket is always routed to enrolment, abandoning registration mid-enrolment needs no cleanup — and bringing existing accounts under the requirement (US4) needed no code of its own.

## Security

Replay guard on the accepted time step; per-interaction and per-account throttles; one indistinguishable refusal for every failure mode; the secret barred from every read by a single `presentUser` presenter, swept by `test/mcp/secrecy.spec.ts`. Clearing an enrolment ends sessions but leaves grants and tokens — a reset, not a deletion.

`amr: ['pwd','otp']` reaches the ID token. Password-only sign-ins are deliberately left without `amr`, so a non-requiring bucket is observably unchanged. Federated sign-in is never gated.

## Two pre-existing defects found

- `Interaction.persist()` can never succeed — its guard reads `this.exp` while the value lives at `this.payload.exp`. Zero callers before now. Worked around, not fixed, to keep this diff scoped.
- The MongoDB user store's `$set`-only patch could not clear a field, so clearing an enrolment would have silently left a revoked authenticator working. Now splits `$set`/`$unset`; the in-memory store was converged to match.

## Verification

- `bun test`: 3228 pass / 3 skip / 0 fail (208 files); baseline was 3122/202
- `bun run typecheck`: 2624 — exactly the baseline, zero new errors
- `bun run format` clean; `bun run build` clean (+32 KB on `loginClient.js` for the QR encoder)
- Provisioned and exercised against real MongoDB; both new areas carry the derived owner and TTL indexes
- Driven in a real browser: the QR survives hydration (180×180, styled), a correct password alone sets no session cookie, and the resulting session carries `['pwd','otp']`

Not verified: a federated sign-in in a requiring bucket demanding no code needs a live upstream IdP. The `totpRequired` branch exists only in the password POST, and `test/federation/` passes unchanged.

Also includes two formatting-only hunks in `lib/admin/auth/login.ts` and `lib/shared/destroy_session.ts` — pre-existing prettier drift the format run picked up.

Design notes: `wiki/concepts/totp-second-factor.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)